### PR TITLE
[打磨-竞品差异化] FieldFlow — 三大核心改动

### DIFF
--- a/apps/fieldflow/src/app/invoices/page.tsx
+++ b/apps/fieldflow/src/app/invoices/page.tsx
@@ -1,14 +1,15 @@
 "use client";
 
 import Link from "next/link";
-import { Plus, FileText } from "lucide-react";
+import { Plus, FileText, Download } from "lucide-react";
 import { useStore } from "@/store/useStore";
 import { StatusBadge } from "@/components/StatusBadge";
 import { EmptyState } from "@/components/EmptyState";
 import { formatCurrency, formatDate } from "@/lib/utils";
+import { exportInvoicesCSV } from "@/lib/export";
 
 /**
- * @description 发票列表页
+ * @description 发票列表页（含免费CSV导出）
  */
 export default function InvoicesPage() {
   const invoices = useStore((s) => s.invoices);
@@ -23,13 +24,24 @@ export default function InvoicesPage() {
     <div className="px-4 pt-6">
       <div className="mb-6 flex items-center justify-between">
         <h1 className="text-2xl font-bold">Invoices</h1>
-        <Link
-          href="/invoices/new"
-          className="flex items-center gap-1.5 rounded-xl bg-primary px-4 py-2 text-sm font-medium text-white shadow-sm transition-colors hover:bg-primary-dark"
-        >
-          <Plus size={16} />
-          New Invoice
-        </Link>
+        <div className="flex items-center gap-2">
+          {invoices.length > 0 && (
+            <button
+              onClick={() => exportInvoicesCSV(invoices, settings)}
+              className="flex h-9 w-9 items-center justify-center rounded-xl bg-surface shadow-sm transition-colors hover:bg-gray-50 dark:bg-surface-dark dark:hover:bg-gray-800"
+              title="Export CSV"
+            >
+              <Download size={16} className="text-text-muted" />
+            </button>
+          )}
+          <Link
+            href="/invoices/new"
+            className="flex items-center gap-1.5 rounded-xl bg-primary px-4 py-2 text-sm font-medium text-white shadow-sm transition-colors hover:bg-primary-dark"
+          >
+            <Plus size={16} />
+            New Invoice
+          </Link>
+        </div>
       </div>
 
       {sortedInvoices.length === 0 ? (

--- a/apps/fieldflow/src/app/jobs/new/page.tsx
+++ b/apps/fieldflow/src/app/jobs/new/page.tsx
@@ -1,21 +1,42 @@
 "use client";
 
-import { useState } from "react";
-import { useRouter } from "next/navigation";
-import { ArrowLeft } from "lucide-react";
+import { useState, Suspense } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { ArrowLeft, Zap, ChevronRight, ChevronLeft } from "lucide-react";
 import Link from "next/link";
 import { useStore } from "@/store/useStore";
 import { generateId } from "@/lib/utils";
 import type { Job, Customer, JobStatus } from "@/types";
 
 /**
- * @description 新建工作任务页
+ * @description 新建工作任务页（含快速三步创建模式）
  */
 export default function NewJobPage() {
+  return (
+    <Suspense
+      fallback={
+        <div className="flex min-h-[60vh] items-center justify-center">
+          <div className="h-8 w-8 animate-spin rounded-full border-4 border-primary border-t-transparent" />
+        </div>
+      }
+    >
+      <NewJobForm />
+    </Suspense>
+  );
+}
+
+/**
+ * @description 内部表单组件，支持 quick 模式（3 步快速创建）和完整模式
+ */
+function NewJobForm() {
   const router = useRouter();
+  const searchParams = useSearchParams();
+  const isQuickMode = searchParams.get("quick") === "1";
+
   const { addJob, addCustomer, customers, isFreeLimitReached, settings } =
     useStore();
 
+  const [quickStep, setQuickStep] = useState(1);
   const [form, setForm] = useState({
     title: "",
     description: "",
@@ -35,8 +56,8 @@ export default function NewJobPage() {
 
   const limitReached = isFreeLimitReached();
 
-  const handleSubmit = (e: React.FormEvent) => {
-    e.preventDefault();
+  const handleSubmit = (e?: React.FormEvent) => {
+    if (e) e.preventDefault();
 
     if (limitReached) {
       alert(
@@ -52,7 +73,7 @@ export default function NewJobPage() {
     } else {
       customer = {
         id: generateId(),
-        name: form.customerName,
+        name: form.customerName || "Walk-in Customer",
         email: form.customerEmail,
         phone: form.customerPhone,
         address: form.customerAddress,
@@ -69,8 +90,10 @@ export default function NewJobPage() {
       customer,
       location: form.location || customer.address,
       status: form.status,
-      scheduledDate: form.scheduledDate,
-      scheduledTime: form.scheduledTime,
+      scheduledDate: form.scheduledDate || new Date().toISOString().slice(0, 10),
+      scheduledTime:
+        form.scheduledTime ||
+        `${String(new Date().getHours()).padStart(2, "0")}:${String(new Date().getMinutes()).padStart(2, "0")}`,
       estimatedDuration: form.estimatedDuration,
       price: form.price,
       notes: form.notes,
@@ -113,16 +136,214 @@ export default function NewJobPage() {
   const inputClass =
     "w-full rounded-xl border border-border bg-surface px-4 py-2.5 text-sm outline-none transition-colors focus:border-primary focus:ring-2 focus:ring-primary/20 dark:border-border-dark dark:bg-surface-dark";
 
+  if (isQuickMode) {
+    return (
+      <div className="px-4 pt-6">
+        <div className="mb-6 flex items-center gap-3">
+          <Link
+            href="/jobs"
+            className="flex h-9 w-9 items-center justify-center rounded-full bg-surface shadow-sm dark:bg-surface-dark"
+          >
+            <ArrowLeft size={18} />
+          </Link>
+          <div className="flex items-center gap-2">
+            <Zap size={20} className="text-primary" />
+            <h1 className="text-2xl font-bold">Quick Job</h1>
+          </div>
+        </div>
+
+        {/* Step indicator */}
+        <div className="mb-6 flex items-center gap-2">
+          {[1, 2, 3].map((step) => (
+            <div key={step} className="flex flex-1 items-center gap-2">
+              <div
+                className={`flex h-8 w-8 items-center justify-center rounded-full text-sm font-bold transition-colors ${
+                  step === quickStep
+                    ? "bg-primary text-white"
+                    : step < quickStep
+                      ? "bg-green-500 text-white"
+                      : "bg-gray-200 text-gray-500 dark:bg-gray-700 dark:text-gray-400"
+                }`}
+              >
+                {step < quickStep ? "✓" : step}
+              </div>
+              {step < 3 && (
+                <div
+                  className={`h-0.5 flex-1 transition-colors ${
+                    step < quickStep ? "bg-green-500" : "bg-gray-200 dark:bg-gray-700"
+                  }`}
+                />
+              )}
+            </div>
+          ))}
+        </div>
+
+        <div className="mb-2 text-xs font-medium text-text-muted dark:text-text-muted-dark">
+          Step {quickStep} of 3
+        </div>
+
+        {limitReached && (
+          <div className="mb-4 rounded-xl bg-orange-50 p-4 text-sm text-orange-800 dark:bg-orange-900/20 dark:text-orange-300">
+            <strong>Free tier limit reached.</strong> You&apos;ve used 5 jobs
+            this month.{" "}
+            <Link href="/settings" className="font-medium underline">
+              Upgrade to Pro
+            </Link>{" "}
+            for unlimited access.
+          </div>
+        )}
+
+        {/* Step 1: What */}
+        {quickStep === 1 && (
+          <div className="space-y-4">
+            <h2 className="text-lg font-semibold">What&apos;s the job?</h2>
+            <input
+              type="text"
+              placeholder="e.g. Fix leaky faucet, AC repair..."
+              autoFocus
+              value={form.title}
+              onChange={(e) => updateField("title", e.target.value)}
+              className={`${inputClass} !py-3.5 text-base`}
+            />
+            <div className="relative">
+              <span className="absolute left-4 top-1/2 -translate-y-1/2 text-sm text-text-muted">
+                {settings.currency}
+              </span>
+              <input
+                type="number"
+                min={0}
+                step={0.01}
+                placeholder="Price (optional)"
+                value={form.price || ""}
+                onChange={(e) => updateField("price", Number(e.target.value))}
+                className={`${inputClass} pl-14`}
+              />
+            </div>
+            <button
+              disabled={!form.title.trim()}
+              onClick={() => setQuickStep(2)}
+              className="flex w-full items-center justify-center gap-2 rounded-xl bg-primary py-3 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-primary-dark disabled:opacity-50"
+            >
+              Next <ChevronRight size={16} />
+            </button>
+          </div>
+        )}
+
+        {/* Step 2: Who */}
+        {quickStep === 2 && (
+          <div className="space-y-4">
+            <h2 className="text-lg font-semibold">Who&apos;s the customer?</h2>
+            {customers.length > 0 && (
+              <select
+                value={form.existingCustomerId}
+                onChange={(e) => selectExistingCustomer(e.target.value)}
+                className={inputClass}
+              >
+                <option value="">New Customer</option>
+                {customers.map((c) => (
+                  <option key={c.id} value={c.id}>
+                    {c.name}
+                  </option>
+                ))}
+              </select>
+            )}
+            <input
+              type="text"
+              placeholder="Customer Name"
+              autoFocus={customers.length === 0}
+              value={form.customerName}
+              onChange={(e) => updateField("customerName", e.target.value)}
+              className={inputClass}
+              disabled={!!form.existingCustomerId}
+            />
+            <input
+              type="tel"
+              placeholder="Phone (optional)"
+              value={form.customerPhone}
+              onChange={(e) => updateField("customerPhone", e.target.value)}
+              className={inputClass}
+              disabled={!!form.existingCustomerId}
+            />
+            <div className="flex gap-3">
+              <button
+                onClick={() => setQuickStep(1)}
+                className="flex items-center justify-center gap-1 rounded-xl bg-surface px-4 py-3 text-sm font-medium shadow-sm dark:bg-surface-dark"
+              >
+                <ChevronLeft size={16} /> Back
+              </button>
+              <button
+                onClick={() => setQuickStep(3)}
+                className="flex flex-1 items-center justify-center gap-2 rounded-xl bg-primary py-3 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-primary-dark"
+              >
+                Next <ChevronRight size={16} />
+              </button>
+            </div>
+          </div>
+        )}
+
+        {/* Step 3: When */}
+        {quickStep === 3 && (
+          <div className="space-y-4">
+            <h2 className="text-lg font-semibold">When?</h2>
+            <input
+              type="date"
+              value={form.scheduledDate}
+              onChange={(e) => updateField("scheduledDate", e.target.value)}
+              className={inputClass}
+            />
+            <input
+              type="time"
+              value={form.scheduledTime}
+              onChange={(e) => updateField("scheduledTime", e.target.value)}
+              className={inputClass}
+            />
+            <input
+              type="text"
+              placeholder="Location / Address (optional)"
+              value={form.location}
+              onChange={(e) => updateField("location", e.target.value)}
+              className={inputClass}
+            />
+            <div className="flex gap-3">
+              <button
+                onClick={() => setQuickStep(2)}
+                className="flex items-center justify-center gap-1 rounded-xl bg-surface px-4 py-3 text-sm font-medium shadow-sm dark:bg-surface-dark"
+              >
+                <ChevronLeft size={16} /> Back
+              </button>
+              <button
+                disabled={limitReached}
+                onClick={() => handleSubmit()}
+                className="flex flex-1 items-center justify-center gap-2 rounded-xl bg-green-600 py-3 text-sm font-bold text-white shadow-sm transition-colors hover:bg-green-700 disabled:opacity-50"
+              >
+                <Zap size={16} /> Create Job
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+    );
+  }
+
   return (
     <div className="px-4 pt-6">
-      <div className="mb-6 flex items-center gap-3">
+      <div className="mb-6 flex items-center justify-between">
+        <div className="flex items-center gap-3">
+          <Link
+            href="/jobs"
+            className="flex h-9 w-9 items-center justify-center rounded-full bg-surface shadow-sm dark:bg-surface-dark"
+          >
+            <ArrowLeft size={18} />
+          </Link>
+          <h1 className="text-2xl font-bold">New Job</h1>
+        </div>
         <Link
-          href="/jobs"
-          className="flex h-9 w-9 items-center justify-center rounded-full bg-surface shadow-sm dark:bg-surface-dark"
+          href="/jobs/new?quick=1"
+          className="flex items-center gap-1.5 rounded-full bg-primary/10 px-3 py-1.5 text-xs font-semibold text-primary transition-colors hover:bg-primary/20"
         >
-          <ArrowLeft size={18} />
+          <Zap size={14} />
+          Quick Mode
         </Link>
-        <h1 className="text-2xl font-bold">New Job</h1>
       </div>
 
       {limitReached && (

--- a/apps/fieldflow/src/app/jobs/page.tsx
+++ b/apps/fieldflow/src/app/jobs/page.tsx
@@ -1,11 +1,12 @@
 "use client";
 
 import Link from "next/link";
-import { Plus, Briefcase, MapPin } from "lucide-react";
+import { Plus, Briefcase, MapPin, Download } from "lucide-react";
 import { useStore } from "@/store/useStore";
 import { StatusBadge } from "@/components/StatusBadge";
 import { EmptyState } from "@/components/EmptyState";
 import { formatCurrency, formatDate } from "@/lib/utils";
+import { exportJobsCSV } from "@/lib/export";
 import { useState } from "react";
 import type { JobStatus } from "@/types";
 
@@ -17,7 +18,7 @@ const FILTER_TABS: { label: string; value: JobStatus | "all" }[] = [
 ];
 
 /**
- * @description 工作列表页
+ * @description 工作列表页（含免费CSV导出）
  */
 export default function JobsPage() {
   const jobs = useStore((s) => s.jobs);
@@ -34,13 +35,24 @@ export default function JobsPage() {
     <div className="px-4 pt-6">
       <div className="mb-6 flex items-center justify-between">
         <h1 className="text-2xl font-bold">Jobs</h1>
-        <Link
-          href="/jobs/new"
-          className="flex items-center gap-1.5 rounded-xl bg-primary px-4 py-2 text-sm font-medium text-white shadow-sm transition-colors hover:bg-primary-dark"
-        >
-          <Plus size={16} />
-          New Job
-        </Link>
+        <div className="flex items-center gap-2">
+          {jobs.length > 0 && (
+            <button
+              onClick={() => exportJobsCSV(jobs, settings)}
+              className="flex h-9 w-9 items-center justify-center rounded-xl bg-surface shadow-sm transition-colors hover:bg-gray-50 dark:bg-surface-dark dark:hover:bg-gray-800"
+              title="Export CSV"
+            >
+              <Download size={16} className="text-text-muted" />
+            </button>
+          )}
+          <Link
+            href="/jobs/new"
+            className="flex items-center gap-1.5 rounded-xl bg-primary px-4 py-2 text-sm font-medium text-white shadow-sm transition-colors hover:bg-primary-dark"
+          >
+            <Plus size={16} />
+            New Job
+          </Link>
+        </div>
       </div>
 
       {/* Filter Tabs */}

--- a/apps/fieldflow/src/app/page.tsx
+++ b/apps/fieldflow/src/app/page.tsx
@@ -9,13 +9,18 @@ import {
   Plus,
   TrendingUp,
   Clock,
+  Zap,
+  Shield,
+  Download,
+  CheckCircle2,
+  X,
 } from "lucide-react";
 import { useStore } from "@/store/useStore";
 import { formatCurrency, isToday } from "@/lib/utils";
 import { StatusBadge } from "@/components/StatusBadge";
 
 /**
- * @description 首页仪表盘
+ * @description 首页仪表盘，含竞品差异化卖点区域
  */
 export default function HomePage() {
   const jobs = useStore((s) => s.jobs);
@@ -32,6 +37,8 @@ export default function HomePage() {
   const totalRevenue = invoices
     .filter((inv) => inv.paymentStatus === "paid")
     .reduce((sum, inv) => sum + inv.paidAmount, 0);
+
+  const isNewUser = jobs.length === 0 && invoices.length === 0;
 
   const stats = [
     {
@@ -64,6 +71,15 @@ export default function HomePage() {
     },
   ];
 
+  const competitorComparison = [
+    { feature: "Sign-up required", us: false, them: true },
+    { feature: "Free data export (CSV)", us: true, them: false },
+    { feature: "Free PDF invoices", us: true, them: false },
+    { feature: "Transparent pricing", us: true, them: false },
+    { feature: "Works offline (PWA)", us: true, them: false },
+    { feature: "Starting price", usLabel: "$0/mo", themLabel: "$39–89/mo" },
+  ];
+
   return (
     <div className="px-4 pt-6">
       <div className="mb-6 flex items-center justify-between">
@@ -84,6 +100,41 @@ export default function HomePage() {
           <Plus size={20} />
         </Link>
       </div>
+
+      {/* Hero Tagline — visible to all, especially impactful for new users */}
+      {isNewUser && (
+        <div className="mb-6 overflow-hidden rounded-2xl bg-gradient-to-br from-primary to-blue-700 p-5 text-white shadow-lg">
+          <h2 className="mb-1 text-lg font-extrabold leading-tight">
+            Zero signup. Zero hidden fees.
+            <br />
+            Manage field work in seconds, not hours.
+          </h2>
+          <p className="mb-4 text-sm text-blue-100">
+            Unlike Jobber ($39–449/mo) or Housecall Pro ($79–468/mo), FieldFlow
+            is free to start — no credit card, no sales calls, no lock-in.
+          </p>
+          <div className="flex flex-wrap gap-3">
+            <div className="flex items-center gap-1.5 text-xs font-medium">
+              <Shield size={14} />
+              <span>No registration</span>
+            </div>
+            <div className="flex items-center gap-1.5 text-xs font-medium">
+              <Download size={14} />
+              <span>Free CSV & PDF export</span>
+            </div>
+            <div className="flex items-center gap-1.5 text-xs font-medium">
+              <Zap size={14} />
+              <span>3-step job creation</span>
+            </div>
+          </div>
+          <Link
+            href="/jobs/new?quick=1"
+            className="mt-4 inline-block rounded-xl bg-white px-5 py-2.5 text-sm font-bold text-primary shadow-sm transition-transform hover:scale-105"
+          >
+            Create Your First Job — Free
+          </Link>
+        </div>
+      )}
 
       {/* Stats Grid */}
       <div className="mb-8 grid grid-cols-2 gap-3">
@@ -110,30 +161,39 @@ export default function HomePage() {
         <h2 className="mb-3 text-sm font-semibold uppercase tracking-wider text-text-muted dark:text-text-muted-dark">
           Quick Actions
         </h2>
-        <div className="grid grid-cols-2 gap-3">
+        <div className="grid grid-cols-3 gap-3">
+          <Link
+            href="/jobs/new?quick=1"
+            className="flex flex-col items-center gap-2 rounded-xl bg-gradient-to-br from-primary/10 to-blue-50 p-4 shadow-sm transition-shadow hover:shadow-md dark:from-primary/20 dark:to-blue-900/10"
+          >
+            <div className="rounded-lg bg-primary/10 p-2">
+              <Zap size={18} className="text-primary" />
+            </div>
+            <span className="text-xs font-semibold text-primary">Quick Job</span>
+          </Link>
           <Link
             href="/jobs/new"
-            className="flex items-center gap-3 rounded-xl bg-surface p-4 shadow-sm transition-shadow hover:shadow-md dark:bg-surface-dark"
+            className="flex flex-col items-center gap-2 rounded-xl bg-surface p-4 shadow-sm transition-shadow hover:shadow-md dark:bg-surface-dark"
           >
             <div className="rounded-lg bg-primary/10 p-2">
               <Briefcase size={18} className="text-primary" />
             </div>
-            <span className="text-sm font-medium">New Job</span>
+            <span className="text-xs font-medium">New Job</span>
           </Link>
           <Link
             href="/invoices/new"
-            className="flex items-center gap-3 rounded-xl bg-surface p-4 shadow-sm transition-shadow hover:shadow-md dark:bg-surface-dark"
+            className="flex flex-col items-center gap-2 rounded-xl bg-surface p-4 shadow-sm transition-shadow hover:shadow-md dark:bg-surface-dark"
           >
             <div className="rounded-lg bg-green-500/10 p-2">
               <DollarSign size={18} className="text-green-500" />
             </div>
-            <span className="text-sm font-medium">New Invoice</span>
+            <span className="text-xs font-medium">Invoice</span>
           </Link>
         </div>
       </div>
 
       {/* Upcoming Jobs */}
-      <div>
+      <div className="mb-8">
         <div className="mb-3 flex items-center justify-between">
           <h2 className="text-sm font-semibold uppercase tracking-wider text-text-muted dark:text-text-muted-dark">
             Upcoming Jobs
@@ -175,6 +235,55 @@ export default function HomePage() {
             ))}
           </div>
         )}
+      </div>
+
+      {/* Why FieldFlow — Competitor Comparison (always visible) */}
+      <div className="mb-8">
+        <h2 className="mb-3 text-sm font-semibold uppercase tracking-wider text-text-muted dark:text-text-muted-dark">
+          Why FieldFlow
+        </h2>
+        <div className="overflow-hidden rounded-2xl bg-surface shadow-sm dark:bg-surface-dark">
+          <div className="grid grid-cols-3 border-b border-border bg-gray-50 px-4 py-2.5 text-xs font-semibold dark:border-border-dark dark:bg-surface-dark">
+            <span className="text-text-muted dark:text-text-muted-dark">Feature</span>
+            <span className="text-center text-primary">FieldFlow</span>
+            <span className="text-center text-text-muted dark:text-text-muted-dark">Others</span>
+          </div>
+          {competitorComparison.map((row) => (
+            <div
+              key={row.feature}
+              className="grid grid-cols-3 border-b border-border/50 px-4 py-2.5 text-xs last:border-b-0 dark:border-border-dark/50"
+            >
+              <span className="text-text dark:text-text-dark">{row.feature}</span>
+              {"usLabel" in row ? (
+                <>
+                  <span className="text-center font-bold text-green-600 dark:text-green-400">
+                    {row.usLabel}
+                  </span>
+                  <span className="text-center font-medium text-red-500 dark:text-red-400">
+                    {row.themLabel}
+                  </span>
+                </>
+              ) : (
+                <>
+                  <span className="flex justify-center">
+                    {row.us ? (
+                      <CheckCircle2 size={16} className="text-green-500" />
+                    ) : (
+                      <X size={16} className="text-red-400" />
+                    )}
+                  </span>
+                  <span className="flex justify-center">
+                    {row.them ? (
+                      <CheckCircle2 size={16} className="text-green-500" />
+                    ) : (
+                      <X size={16} className="text-red-400" />
+                    )}
+                  </span>
+                </>
+              )}
+            </div>
+          ))}
+        </div>
       </div>
     </div>
   );

--- a/apps/fieldflow/src/app/settings/page.tsx
+++ b/apps/fieldflow/src/app/settings/page.tsx
@@ -1,12 +1,13 @@
 "use client";
 
 import { useStore } from "@/store/useStore";
-import { Moon, Sun, Crown, Check } from "lucide-react";
+import { Moon, Sun, Crown, Check, Download, FileSpreadsheet } from "lucide-react";
+import { exportJobsCSV, exportInvoicesCSV, exportAllDataCSV } from "@/lib/export";
 
 const CURRENCIES = ["USD", "EUR", "GBP", "CAD", "AUD", "JPY", "CNY"];
 
 /**
- * @description 设置页面（含订阅管理和深色模式）
+ * @description 设置页面（含订阅管理、深色模式、免费数据导出）
  */
 export default function SettingsPage() {
   const { settings, updateSettings, setSubscription, jobs, invoices } =
@@ -137,6 +138,47 @@ export default function SettingsPage() {
         </div>
       </section>
 
+      {/* Data Export — Free, unlike competitors */}
+      <section className="mb-6">
+        <div className="mb-3 flex items-center gap-2">
+          <h2 className="text-sm font-semibold uppercase tracking-wider text-text-muted dark:text-text-muted-dark">
+            Data Export
+          </h2>
+          <span className="rounded-full bg-green-100 px-2 py-0.5 text-[10px] font-bold uppercase text-green-700 dark:bg-green-900/30 dark:text-green-400">
+            Free
+          </span>
+        </div>
+        <p className="mb-3 text-xs text-text-muted dark:text-text-muted-dark">
+          Export your data anytime — no paywall, no lock-in. Your data is yours.
+        </p>
+        <div className="grid grid-cols-2 gap-3">
+          <button
+            onClick={() => exportJobsCSV(jobs, settings)}
+            disabled={jobs.length === 0}
+            className="flex items-center justify-center gap-2 rounded-xl bg-surface py-2.5 text-sm font-medium shadow-sm transition-colors hover:bg-gray-50 disabled:opacity-40 dark:bg-surface-dark dark:hover:bg-gray-800"
+          >
+            <FileSpreadsheet size={16} className="text-blue-500" />
+            Jobs CSV
+          </button>
+          <button
+            onClick={() => exportInvoicesCSV(invoices, settings)}
+            disabled={invoices.length === 0}
+            className="flex items-center justify-center gap-2 rounded-xl bg-surface py-2.5 text-sm font-medium shadow-sm transition-colors hover:bg-gray-50 disabled:opacity-40 dark:bg-surface-dark dark:hover:bg-gray-800"
+          >
+            <FileSpreadsheet size={16} className="text-green-500" />
+            Invoices CSV
+          </button>
+        </div>
+        <button
+          onClick={() => exportAllDataCSV(jobs, invoices, settings)}
+          disabled={jobs.length === 0 && invoices.length === 0}
+          className="mt-3 flex w-full items-center justify-center gap-2 rounded-xl bg-primary/10 py-2.5 text-sm font-semibold text-primary transition-colors hover:bg-primary/20 disabled:opacity-40"
+        >
+          <Download size={16} />
+          Export All Data
+        </button>
+      </section>
+
       {/* Subscription */}
       <section className="mb-6">
         <h2 className="mb-3 text-sm font-semibold uppercase tracking-wider text-text-muted dark:text-text-muted-dark">
@@ -156,7 +198,7 @@ export default function SettingsPage() {
               <span className="text-lg font-bold">$0</span>
             </div>
             <p className="text-xs text-text-muted dark:text-text-muted-dark">
-              1 user, 5 jobs/month
+              1 user, 5 jobs/month, free CSV & PDF export
             </p>
             {settings.subscription === "free" && (
               <span className="mt-2 inline-flex items-center gap-1 text-xs font-medium text-primary">

--- a/apps/fieldflow/src/lib/export.ts
+++ b/apps/fieldflow/src/lib/export.ts
@@ -1,0 +1,138 @@
+import type { Job, Invoice, UserSettings } from "@/types";
+
+/**
+ * @description 将二维数组转换为 CSV 字符串（含正确的转义处理）
+ * @param {string[][]} rows - 二维数组，每行为一条记录
+ * @returns {string} RFC 4180 兼容的 CSV 字符串
+ */
+function toCSV(rows: string[][]): string {
+  return rows
+    .map((row) =>
+      row
+        .map((cell) => {
+          const escaped = String(cell ?? "").replace(/"/g, '""');
+          return /[",\n\r]/.test(escaped) ? `"${escaped}"` : escaped;
+        })
+        .join(",")
+    )
+    .join("\n");
+}
+
+/**
+ * @description 触发浏览器下载指定内容的文件
+ * @param {string} content - 文件内容
+ * @param {string} filename - 文件名
+ * @param {string} mimeType - MIME 类型
+ */
+function downloadFile(content: string, filename: string, mimeType: string) {
+  const bom = "\uFEFF";
+  const blob = new Blob([bom + content], { type: `${mimeType};charset=utf-8` });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
+}
+
+/**
+ * @description 导出工作任务为 CSV 文件
+ * @param {Job[]} jobs - 工作任务列表
+ * @param {UserSettings} settings - 用户设置
+ */
+export function exportJobsCSV(jobs: Job[], settings: UserSettings): void {
+  const header = [
+    "Title",
+    "Status",
+    "Customer",
+    "Customer Email",
+    "Customer Phone",
+    "Location",
+    "Scheduled Date",
+    "Scheduled Time",
+    "Duration (min)",
+    `Price (${settings.currency})`,
+    "Notes",
+    "Created At",
+  ];
+
+  const rows = jobs.map((j) => [
+    j.title,
+    j.status,
+    j.customer.name,
+    j.customer.email,
+    j.customer.phone,
+    j.location,
+    j.scheduledDate,
+    j.scheduledTime,
+    String(j.estimatedDuration),
+    String(j.price),
+    j.notes || "",
+    j.createdAt,
+  ]);
+
+  const csv = toCSV([header, ...rows]);
+  const date = new Date().toISOString().slice(0, 10);
+  downloadFile(csv, `fieldflow-jobs-${date}.csv`, "text/csv");
+}
+
+/**
+ * @description 导出发票为 CSV 文件
+ * @param {Invoice[]} invoices - 发票列表
+ * @param {UserSettings} settings - 用户设置
+ */
+export function exportInvoicesCSV(
+  invoices: Invoice[],
+  settings: UserSettings
+): void {
+  const header = [
+    "Invoice #",
+    "Customer",
+    "Status",
+    "Payment Status",
+    `Subtotal (${settings.currency})`,
+    `Tax (${settings.currency})`,
+    `Total (${settings.currency})`,
+    `Paid Amount (${settings.currency})`,
+    "Due Date",
+    "Paid Date",
+    "Items",
+    "Created At",
+  ];
+
+  const rows = invoices.map((inv) => [
+    inv.invoiceNumber,
+    inv.customer.name,
+    inv.invoiceStatus,
+    inv.paymentStatus,
+    String(inv.subtotal),
+    String(inv.tax),
+    String(inv.total),
+    String(inv.paidAmount),
+    inv.dueDate,
+    inv.paidDate || "",
+    inv.items.map((i) => `${i.description} x${i.quantity}`).join("; "),
+    inv.createdAt,
+  ]);
+
+  const csv = toCSV([header, ...rows]);
+  const date = new Date().toISOString().slice(0, 10);
+  downloadFile(csv, `fieldflow-invoices-${date}.csv`, "text/csv");
+}
+
+/**
+ * @description 导出所有数据为 CSV（工作 + 发票打包）
+ * @param {Job[]} jobs - 工作列表
+ * @param {Invoice[]} invoices - 发票列表
+ * @param {UserSettings} settings - 用户设置
+ */
+export function exportAllDataCSV(
+  jobs: Job[],
+  invoices: Invoice[],
+  settings: UserSettings
+): void {
+  exportJobsCSV(jobs, settings);
+  setTimeout(() => exportInvoicesCSV(invoices, settings), 300);
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 竞品分析

分析了 Field Service Management 领域前三竞品：

| 竞品 | 起步价 | 实际价格 | 核心痛点 |
|------|--------|---------|---------|
| **Jobber** | $39/mo | $39–449/mo | BBB F 评级、导出功能锁付费版、每周 3-5 小时手动录入 |
| **Housecall Pro** | $79/mo | $79–468/mo | 界面复杂、高级功能要高付费版、注册必须信用卡 |
| **FieldPulse** | $89/mo | 隐藏定价 | 不透明定价、必须电话咨询、有限自动化 |

## 竞品差异化改动（3 个）

### 1. 首页卖点 + 竞品对比表
- 新用户首次访问看到 **Hero 区域**，一句话卖点：**「Zero signup. Zero hidden fees. Manage field work in seconds, not hours.」**
- 对比 Jobber ($39–449/mo) 和 Housecall Pro ($79–468/mo) 的价格
- 常驻 **"Why FieldFlow" 对比表**，6 项对比维度：注册门槛、免费导出、PDF 发票、透明定价、离线支持、起步价格

### 2. 免费 CSV 数据导出（竞品锁付费版）
- 新增 `src/lib/export.ts` — 支持工作任务和发票的 CSV 导出
- 在 **Jobs 列表页、Invoices 列表页** 添加一键导出按钮
- 在 **Settings 页** 添加「Data Export」专区，可分别或一次性导出所有数据
- 标注 **"Free"** 徽章，明确传达「你的数据是你的」
- **竞品对比**：Jobber 用户反馈无法轻松导出数据到 Excel；Housecall Pro 将完整报告锁在高付费版

### 3. 三步快速创建工作（Quick Job）
- 新增 `/jobs/new?quick=1` 快速创建模式
- 只需 **3 步**：What（什么工作 + 价格） → Who（哪个客户） → When（什么时候）
- 带进度指示器，可前后导航
- 首页「Quick Actions」新增 **Quick Job** 快捷入口（渐变高亮）
- 完整模式保留不变，增加切换到 Quick Mode 的入口
- **竞品对比**：Jobber 基础版用户每周需 3-5 小时手动数据录入；我们秒级完成

## 技术细节
- 所有新代码通过 **build + lint + 25 个测试**
- 新增 1 个文件 (`export.ts`)，修改 5 个文件
- 无新依赖
- 向后兼容，不影响现有数据
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2dc8046f-3718-4243-9141-4e2cf6d91d40"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2dc8046f-3718-4243-9141-4e2cf6d91d40"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

