### PR TITLE
feat(pedallink-pro): PedalLink Pro — iOS MIDI 脚踏板映射工具 MVP

### DIFF
--- a/apps/pedallink-pro/.gitignore
+++ b/apps/pedallink-pro/.gitignore
@@ -1,0 +1,35 @@
+# Xcode
+build/
+DerivedData/
+*.xcuserdata
+*.xcworkspace
+xcuserdata/
+*.moved-aside
+*.pbxuser
+!default.pbxuser
+*.mode1v3
+!default.mode1v3
+*.mode2v3
+!default.mode2v3
+*.perspectivev3
+!default.perspectivev3
+
+# Swift Package Manager
+.build/
+Packages/
+Package.pins
+Package.resolved
+
+# CocoaPods
+Pods/
+
+# macOS
+.DS_Store
+*.swp
+*~.nib
+
+# Fastlane
+fastlane/report.xml
+fastlane/Preview.html
+fastlane/screenshots
+fastlane/test_output

--- a/apps/pedallink-pro/PedalLinkPro.xcodeproj/project.pbxproj
+++ b/apps/pedallink-pro/PedalLinkPro.xcodeproj/project.pbxproj
@@ -1,0 +1,527 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 56;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		A10001 /* PedalLinkProApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10001; };
+		A10002 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10002; };
+		A10003 /* MIDIMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10003; };
+		A10004 /* MIDIMapping.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10004; };
+		A10005 /* HostAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10005; };
+		A10006 /* MIDIService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10006; };
+		A10007 /* MappingEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10007; };
+		A10008 /* HostInteropService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10008; };
+		A10009 /* StoreKitService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10009; };
+		A10010 /* MIDIMonitorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10010; };
+		A10011 /* MappingListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10011; };
+		A10012 /* MappingDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10012; };
+		A10013 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10013; };
+		A10014 /* MIDIActivityIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10014; };
+		A10015 /* PedalButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10015; };
+		A10016 /* ActionPickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10016; };
+		A10017 /* MIDIMonitorViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10017; };
+		A10018 /* MappingListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10018; };
+		A10019 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10019; };
+		A10020 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = B10020; };
+		A10030 /* MIDIMessageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10030; };
+		A10031 /* MappingEngineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10031; };
+		A10032 /* HostInteropServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10032; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		C10001 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = D10001;
+			proxyType = 1;
+			remoteGlobalIDString = E10001;
+			remoteInfo = PedalLinkPro;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		B10001 /* PedalLinkProApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PedalLinkProApp.swift; sourceTree = "<group>"; };
+		B10002 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+		B10003 /* MIDIMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MIDIMessage.swift; sourceTree = "<group>"; };
+		B10004 /* MIDIMapping.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MIDIMapping.swift; sourceTree = "<group>"; };
+		B10005 /* HostAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostAction.swift; sourceTree = "<group>"; };
+		B10006 /* MIDIService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MIDIService.swift; sourceTree = "<group>"; };
+		B10007 /* MappingEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MappingEngine.swift; sourceTree = "<group>"; };
+		B10008 /* HostInteropService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostInteropService.swift; sourceTree = "<group>"; };
+		B10009 /* StoreKitService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreKitService.swift; sourceTree = "<group>"; };
+		B10010 /* MIDIMonitorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MIDIMonitorView.swift; sourceTree = "<group>"; };
+		B10011 /* MappingListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MappingListView.swift; sourceTree = "<group>"; };
+		B10012 /* MappingDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MappingDetailView.swift; sourceTree = "<group>"; };
+		B10013 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
+		B10014 /* MIDIActivityIndicator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MIDIActivityIndicator.swift; sourceTree = "<group>"; };
+		B10015 /* PedalButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PedalButton.swift; sourceTree = "<group>"; };
+		B10016 /* ActionPickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActionPickerView.swift; sourceTree = "<group>"; };
+		B10017 /* MIDIMonitorViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MIDIMonitorViewModel.swift; sourceTree = "<group>"; };
+		B10018 /* MappingListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MappingListViewModel.swift; sourceTree = "<group>"; };
+		B10019 /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
+		B10020 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		B10021 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		B10030 /* MIDIMessageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MIDIMessageTests.swift; sourceTree = "<group>"; };
+		B10031 /* MappingEngineTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MappingEngineTests.swift; sourceTree = "<group>"; };
+		B10032 /* HostInteropServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostInteropServiceTests.swift; sourceTree = "<group>"; };
+		F10001 /* PedalLinkPro.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = PedalLinkPro.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		F10002 /* PedalLinkProTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = PedalLinkProTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		G10001 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		G10002 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		H10001 = {
+			isa = PBXGroup;
+			children = (
+				H10002 /* PedalLinkPro */,
+				H10010 /* PedalLinkProTests */,
+				H10020 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		H10002 /* PedalLinkPro */ = {
+			isa = PBXGroup;
+			children = (
+				H10003 /* App */,
+				H10004 /* Models */,
+				H10005 /* Services */,
+				H10006 /* ViewModels */,
+				H10007 /* Views */,
+				H10008 /* Utilities */,
+				H10009 /* Resources */,
+			);
+			path = PedalLinkPro;
+			sourceTree = "<group>";
+		};
+		H10003 /* App */ = {
+			isa = PBXGroup;
+			children = (
+				B10001 /* PedalLinkProApp.swift */,
+			);
+			path = App;
+			sourceTree = "<group>";
+		};
+		H10004 /* Models */ = {
+			isa = PBXGroup;
+			children = (
+				B10003 /* MIDIMessage.swift */,
+				B10004 /* MIDIMapping.swift */,
+				B10005 /* HostAction.swift */,
+			);
+			path = Models;
+			sourceTree = "<group>";
+		};
+		H10005 /* Services */ = {
+			isa = PBXGroup;
+			children = (
+				B10006 /* MIDIService.swift */,
+				B10007 /* MappingEngine.swift */,
+				B10008 /* HostInteropService.swift */,
+				B10009 /* StoreKitService.swift */,
+			);
+			path = Services;
+			sourceTree = "<group>";
+		};
+		H10006 /* ViewModels */ = {
+			isa = PBXGroup;
+			children = (
+				B10017 /* MIDIMonitorViewModel.swift */,
+				B10018 /* MappingListViewModel.swift */,
+			);
+			path = ViewModels;
+			sourceTree = "<group>";
+		};
+		H10007 /* Views */ = {
+			isa = PBXGroup;
+			children = (
+				B10002 /* ContentView.swift */,
+				B10010 /* MIDIMonitorView.swift */,
+				B10011 /* MappingListView.swift */,
+				B10012 /* MappingDetailView.swift */,
+				B10013 /* SettingsView.swift */,
+				H10007A /* Components */,
+			);
+			path = Views;
+			sourceTree = "<group>";
+		};
+		H10007A /* Components */ = {
+			isa = PBXGroup;
+			children = (
+				B10014 /* MIDIActivityIndicator.swift */,
+				B10015 /* PedalButton.swift */,
+				B10016 /* ActionPickerView.swift */,
+			);
+			path = Components;
+			sourceTree = "<group>";
+		};
+		H10008 /* Utilities */ = {
+			isa = PBXGroup;
+			children = (
+				B10019 /* Constants.swift */,
+			);
+			path = Utilities;
+			sourceTree = "<group>";
+		};
+		H10009 /* Resources */ = {
+			isa = PBXGroup;
+			children = (
+				B10020 /* Assets.xcassets */,
+				B10021 /* Info.plist */,
+			);
+			path = Resources;
+			sourceTree = "<group>";
+		};
+		H10010 /* PedalLinkProTests */ = {
+			isa = PBXGroup;
+			children = (
+				B10030 /* MIDIMessageTests.swift */,
+				B10031 /* MappingEngineTests.swift */,
+				B10032 /* HostInteropServiceTests.swift */,
+			);
+			path = PedalLinkProTests;
+			sourceTree = "<group>";
+		};
+		H10020 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				F10001 /* PedalLinkPro.app */,
+				F10002 /* PedalLinkProTests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		E10001 /* PedalLinkPro */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = J10001;
+			buildPhases = (
+				K10001 /* Sources */,
+				G10001 /* Frameworks */,
+				L10001 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = PedalLinkPro;
+			productName = PedalLinkPro;
+			productReference = F10001 /* PedalLinkPro.app */;
+			productType = "com.apple.product-type.application";
+		};
+		E10002 /* PedalLinkProTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = J10002;
+			buildPhases = (
+				K10002 /* Sources */,
+				G10002 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				C10001 /* PBXContainerItemProxy */,
+			);
+			name = PedalLinkProTests;
+			productName = PedalLinkProTests;
+			productReference = F10002 /* PedalLinkProTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		D10001 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 1540;
+				LastUpgradeCheck = 1540;
+				TargetAttributes = {
+					E10001 = {
+						CreatedOnToolsVersion = 15.4;
+					};
+					E10002 = {
+						CreatedOnToolsVersion = 15.4;
+						TestTargetID = E10001;
+					};
+				};
+			};
+			buildConfigurationList = J10003;
+			compatibilityVersion = "Xcode 14.0";
+			developmentRegion = "zh-Hans";
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				"zh-Hans",
+			);
+			mainGroup = H10001;
+			productRefGroup = H10020 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				E10001 /* PedalLinkPro */,
+				E10002 /* PedalLinkProTests */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		L10001 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A10020 /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		K10001 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A10001 /* PedalLinkProApp.swift in Sources */,
+				A10002 /* ContentView.swift in Sources */,
+				A10003 /* MIDIMessage.swift in Sources */,
+				A10004 /* MIDIMapping.swift in Sources */,
+				A10005 /* HostAction.swift in Sources */,
+				A10006 /* MIDIService.swift in Sources */,
+				A10007 /* MappingEngine.swift in Sources */,
+				A10008 /* HostInteropService.swift in Sources */,
+				A10009 /* StoreKitService.swift in Sources */,
+				A10010 /* MIDIMonitorView.swift in Sources */,
+				A10011 /* MappingListView.swift in Sources */,
+				A10012 /* MappingDetailView.swift in Sources */,
+				A10013 /* SettingsView.swift in Sources */,
+				A10014 /* MIDIActivityIndicator.swift in Sources */,
+				A10015 /* PedalButton.swift in Sources */,
+				A10016 /* ActionPickerView.swift in Sources */,
+				A10017 /* MIDIMonitorViewModel.swift in Sources */,
+				A10018 /* MappingListViewModel.swift in Sources */,
+				A10019 /* Constants.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		K10002 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A10030 /* MIDIMessageTests.swift in Sources */,
+				A10031 /* MappingEngineTests.swift in Sources */,
+				A10032 /* HostInteropServiceTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		C10001 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = E10001 /* PedalLinkPro */;
+			targetProxy = C10001 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin XCBuildConfiguration section */
+		M10001 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		M10002 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		M10003 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = "";
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = PedalLinkPro/Resources/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = "PedalLink Pro";
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.pedallinkpro.app;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		M10004 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = "";
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = PedalLinkPro/Resources/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = "PedalLink Pro";
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.pedallinkpro.app;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		M10005 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				MARKETING_VERSION = 1.0.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.pedallinkpro.app.tests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/PedalLinkPro.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/PedalLinkPro";
+			};
+			name = Debug;
+		};
+		M10006 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				MARKETING_VERSION = 1.0.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.pedallinkpro.app.tests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/PedalLinkPro.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/PedalLinkPro";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		J10001 /* Build configuration list for PBXNativeTarget "PedalLinkPro" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				M10003 /* Debug */,
+				M10004 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		J10002 /* Build configuration list for PBXNativeTarget "PedalLinkProTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				M10005 /* Debug */,
+				M10006 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		J10003 /* Build configuration list for PBXProject "PedalLinkPro" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				M10001 /* Debug */,
+				M10002 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+
+	};
+	rootObject = D10001 /* Project object */;
+}

--- a/apps/pedallink-pro/PedalLinkPro/App/PedalLinkProApp.swift
+++ b/apps/pedallink-pro/PedalLinkPro/App/PedalLinkProApp.swift
@@ -1,0 +1,26 @@
+import SwiftUI
+
+/// PedalLink Pro 应用程序入口
+@main
+struct PedalLinkProApp: App {
+    @StateObject private var midiService = MIDIService()
+    @StateObject private var mappingEngine = MappingEngine()
+    @StateObject private var storeService = StoreKitService()
+
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+                .environmentObject(midiService)
+                .environmentObject(mappingEngine)
+                .environmentObject(storeService)
+                .preferredColorScheme(.dark)
+                .onAppear {
+                    midiService.start()
+                    mappingEngine.loadMappings()
+                    midiService.onMIDIMessage = { [weak mappingEngine] message in
+                        mappingEngine?.process(message: message)
+                    }
+                }
+        }
+    }
+}

--- a/apps/pedallink-pro/PedalLinkPro/Models/HostAction.swift
+++ b/apps/pedallink-pro/PedalLinkPro/Models/HostAction.swift
@@ -1,0 +1,75 @@
+import Foundation
+
+/// 宿主软件通道操作类型
+enum ChannelActionType: String, Codable, CaseIterable, Identifiable {
+    case mute = "静音"
+    case solo = "独奏"
+    case selectChannel = "选择通道"
+    case volume = "音量"
+    case pan = "声相"
+    case send = "发送"
+
+    var id: String { rawValue }
+
+    /// 操作图标名称（SF Symbols）
+    var iconName: String {
+        switch self {
+        case .mute: return "speaker.slash.fill"
+        case .solo: return "headphones"
+        case .selectChannel: return "arrow.right.circle.fill"
+        case .volume: return "speaker.wave.2.fill"
+        case .pan: return "slider.horizontal.below.rectangle"
+        case .send: return "arrow.up.right"
+        }
+    }
+}
+
+/// 目标宿主应用枚举
+enum HostApp: String, Codable, CaseIterable, Identifiable {
+    case aum = "AUM"
+    case audiobus = "Audiobus"
+    case garageBand = "GarageBand"
+    case cubasis = "Cubasis"
+    case generic = "通用 MIDI"
+
+    var id: String { rawValue }
+
+    /// 宿主应用的 URL Scheme
+    var urlScheme: String? {
+        switch self {
+        case .aum: return "aum"
+        case .audiobus: return "audiobus"
+        case .garageBand: return "garageband"
+        case .cubasis: return "cubasis"
+        case .generic: return nil
+        }
+    }
+}
+
+/// 宿主操作指令，描述要对目标宿主应用执行的具体操作
+struct HostAction: Codable, Equatable, Identifiable {
+    var id = UUID()
+    var hostApp: HostApp
+    var actionType: ChannelActionType
+    var targetChannel: Int
+    var parameterValue: Int?
+
+    /// 生成操作描述字符串
+    var displayString: String {
+        let channelStr = "通道 \(targetChannel + 1)"
+        switch actionType {
+        case .mute:
+            return "\(hostApp.rawValue) - \(channelStr) 静音切换"
+        case .solo:
+            return "\(hostApp.rawValue) - \(channelStr) 独奏切换"
+        case .selectChannel:
+            return "\(hostApp.rawValue) - 选择\(channelStr)"
+        case .volume:
+            return "\(hostApp.rawValue) - \(channelStr) 音量 \(parameterValue ?? 0)"
+        case .pan:
+            return "\(hostApp.rawValue) - \(channelStr) 声相 \(parameterValue ?? 64)"
+        case .send:
+            return "\(hostApp.rawValue) - \(channelStr) 发送 \(parameterValue ?? 0)"
+        }
+    }
+}

--- a/apps/pedallink-pro/PedalLinkPro/Models/MIDIMapping.swift
+++ b/apps/pedallink-pro/PedalLinkPro/Models/MIDIMapping.swift
@@ -1,0 +1,52 @@
+import Foundation
+
+/// 触发模式：定义脚踏板信号如何触发映射动作
+enum TriggerMode: String, Codable, CaseIterable, Identifiable {
+    case onPress = "按下触发"
+    case onRelease = "释放触发"
+    case toggle = "切换模式"
+    case momentary = "瞬时模式"
+
+    var id: String { rawValue }
+}
+
+/// MIDI 映射规则：将特定 MIDI 输入信号映射到宿主操作
+struct MIDIMapping: Codable, Identifiable, Equatable {
+    var id = UUID()
+    var name: String
+    var isEnabled: Bool = true
+
+    // MIDI 输入条件
+    var messageType: MIDIMessageType = .controlChange
+    var midiChannel: UInt8 = 0
+    var controlNumber: UInt8 = 0
+    var triggerMode: TriggerMode = .onPress
+    var thresholdValue: UInt8 = 64
+
+    // 目标操作
+    var action: HostAction
+
+    /// 检查传入的 MIDI 消息是否匹配此映射规则
+    /// - Parameter message: 传入的 MIDI 消息
+    /// - Returns: 如果消息匹配此映射的输入条件则返回 true
+    func matches(_ message: MIDIMessage) -> Bool {
+        guard isEnabled else { return false }
+        guard message.type == messageType else { return false }
+        guard message.channel == midiChannel else { return false }
+        guard message.number == controlNumber else { return false }
+
+        switch triggerMode {
+        case .onPress, .toggle:
+            return message.value >= thresholdValue
+        case .onRelease:
+            return message.value < thresholdValue
+        case .momentary:
+            return true
+        }
+    }
+
+    /// 映射匹配键，用于快速查找
+    var matchKey: String {
+        "\(messageType.rawValue)_\(midiChannel)_\(controlNumber)"
+    }
+}

--- a/apps/pedallink-pro/PedalLinkPro/Models/MIDIMessage.swift
+++ b/apps/pedallink-pro/PedalLinkPro/Models/MIDIMessage.swift
@@ -1,0 +1,39 @@
+import Foundation
+
+/// MIDI 消息类型枚举
+enum MIDIMessageType: String, Codable, CaseIterable {
+    case controlChange = "CC"
+    case noteOn = "Note On"
+    case noteOff = "Note Off"
+    case programChange = "PC"
+}
+
+/// MIDI 消息模型，表示从外部设备接收的单条 MIDI 数据
+struct MIDIMessage: Identifiable, Equatable {
+    let id = UUID()
+    let timestamp: Date
+    let type: MIDIMessageType
+    let channel: UInt8
+    let number: UInt8
+    let value: UInt8
+    let sourceName: String
+
+    /// 格式化消息用于 UI 显示
+    var displayString: String {
+        switch type {
+        case .controlChange:
+            return "CC \(number) = \(value) [Ch \(channel + 1)]"
+        case .noteOn:
+            return "Note On \(number) vel=\(value) [Ch \(channel + 1)]"
+        case .noteOff:
+            return "Note Off \(number) [Ch \(channel + 1)]"
+        case .programChange:
+            return "PC \(number) [Ch \(channel + 1)]"
+        }
+    }
+
+    /// 用于匹配映射规则的唯一键
+    var matchKey: String {
+        "\(type.rawValue)_\(channel)_\(number)"
+    }
+}

--- a/apps/pedallink-pro/PedalLinkPro/Resources/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/apps/pedallink-pro/PedalLinkPro/Resources/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.000",
+          "green" : "0.584",
+          "red" : "1.000"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.000",
+          "green" : "0.584",
+          "red" : "1.000"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/apps/pedallink-pro/PedalLinkPro/Resources/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/apps/pedallink-pro/PedalLinkPro/Resources/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,13 @@
+{
+  "images" : [
+    {
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/apps/pedallink-pro/PedalLinkPro/Resources/Assets.xcassets/Contents.json
+++ b/apps/pedallink-pro/PedalLinkPro/Resources/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/apps/pedallink-pro/PedalLinkPro/Resources/Info.plist
+++ b/apps/pedallink-pro/PedalLinkPro/Resources/Info.plist
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleDevelopmentRegion</key>
+    <string>zh-Hans</string>
+    <key>CFBundleDisplayName</key>
+    <string>PedalLink Pro</string>
+    <key>CFBundleExecutable</key>
+    <string>$(EXECUTABLE_NAME)</string>
+    <key>CFBundleIdentifier</key>
+    <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+    <key>CFBundleInfoDictionaryVersion</key>
+    <string>6.0</string>
+    <key>CFBundleName</key>
+    <string>$(PRODUCT_NAME)</string>
+    <key>CFBundlePackageType</key>
+    <string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+    <key>CFBundleShortVersionString</key>
+    <string>1.0.0</string>
+    <key>CFBundleVersion</key>
+    <string>1</string>
+    <key>LSRequiresIPhoneOS</key>
+    <true/>
+    <key>UIApplicationSceneManifest</key>
+    <dict>
+        <key>UIApplicationSupportsMultipleScenes</key>
+        <false/>
+    </dict>
+    <key>UIBackgroundModes</key>
+    <array>
+        <string>audio</string>
+    </array>
+    <key>UILaunchScreen</key>
+    <dict>
+        <key>UIColorName</key>
+        <string>LaunchScreenColor</string>
+        <key>UIImageName</key>
+        <string>LaunchScreenImage</string>
+    </dict>
+    <key>UIRequiredDeviceCapabilities</key>
+    <array>
+        <string>armv7</string>
+    </array>
+    <key>UISupportedInterfaceOrientations</key>
+    <array>
+        <string>UIInterfaceOrientationPortrait</string>
+        <string>UIInterfaceOrientationLandscapeLeft</string>
+        <string>UIInterfaceOrientationLandscapeRight</string>
+    </array>
+    <key>UISupportedInterfaceOrientations~ipad</key>
+    <array>
+        <string>UIInterfaceOrientationPortrait</string>
+        <string>UIInterfaceOrientationPortraitUpsideDown</string>
+        <string>UIInterfaceOrientationLandscapeLeft</string>
+        <string>UIInterfaceOrientationLandscapeRight</string>
+    </array>
+    <key>NSMicrophoneUsageDescription</key>
+    <string>PedalLink Pro 需要音频权限以支持后台 MIDI 处理</string>
+</dict>
+</plist>

--- a/apps/pedallink-pro/PedalLinkPro/Services/HostInteropService.swift
+++ b/apps/pedallink-pro/PedalLinkPro/Services/HostInteropService.swift
@@ -1,0 +1,168 @@
+import Foundation
+import CoreMIDI
+import UIKit
+
+/// 宿主互联服务
+///
+/// 负责将映射操作转化为目标宿主应用可识别的控制指令。
+/// 支持两种通信方式：
+/// 1. 虚拟 MIDI 输出（通过 CoreMIDI 虚拟端口发送标准 MIDI 消息）
+/// 2. URL Scheme（用于 AUM 等支持 URL 控制的应用）
+class HostInteropService {
+    private var midiClient: MIDIClientRef = 0
+    private var outputPort: MIDIPortRef = 0
+    private var virtualSource: MIDIEndpointRef = 0
+    private var isSetup = false
+
+    init() {
+        setupVirtualMIDISource()
+    }
+
+    deinit {
+        if virtualSource != 0 {
+            MIDIEndpointDispose(virtualSource)
+        }
+        if midiClient != 0 {
+            MIDIClientDispose(midiClient)
+        }
+    }
+
+    /// 执行宿主操作
+    /// - Parameter action: 要执行的操作指令
+    func execute(action: HostAction) {
+        switch action.hostApp {
+        case .aum:
+            executeAUMAction(action)
+        case .audiobus, .garageBand, .cubasis:
+            executeMIDIAction(action)
+        case .generic:
+            executeMIDIAction(action)
+        }
+    }
+
+    // MARK: - AUM 专用控制
+
+    /// 通过 URL Scheme 执行 AUM 操作
+    ///
+    /// AUM 支持通过 URL Scheme 进行外部控制：
+    /// `aum://control?command=<cmd>&channel=<ch>`
+    private func executeAUMAction(_ action: HostAction) {
+        let channel = action.targetChannel
+
+        switch action.actionType {
+        case .mute:
+            sendAUMURL(command: "toggleMute", channel: channel)
+            sendMIDICC(channel: UInt8(channel), cc: 85, value: 127)
+        case .solo:
+            sendAUMURL(command: "toggleSolo", channel: channel)
+            sendMIDICC(channel: UInt8(channel), cc: 86, value: 127)
+        case .selectChannel:
+            sendAUMURL(command: "selectChannel", channel: channel)
+        case .volume:
+            let value = UInt8(clamping: action.parameterValue ?? 100)
+            sendMIDICC(channel: UInt8(channel), cc: 7, value: value)
+        case .pan:
+            let value = UInt8(clamping: action.parameterValue ?? 64)
+            sendMIDICC(channel: UInt8(channel), cc: 10, value: value)
+        case .send:
+            let value = UInt8(clamping: action.parameterValue ?? 0)
+            sendMIDICC(channel: UInt8(channel), cc: 91, value: value)
+        }
+    }
+
+    /// 通过 URL Scheme 发送 AUM 控制命令
+    /// - Parameters:
+    ///   - command: AUM 命令字符串
+    ///   - channel: 目标通道号
+    private func sendAUMURL(command: String, channel: Int) {
+        guard let url = URL(string: "aum://control?command=\(command)&channel=\(channel)") else { return }
+        DispatchQueue.main.async {
+            UIApplication.shared.open(url, options: [:], completionHandler: nil)
+        }
+    }
+
+    // MARK: - 通用 MIDI 控制
+
+    /// 通过虚拟 MIDI 输出发送操作（适用于所有支持 MIDI 的宿主）
+    private func executeMIDIAction(_ action: HostAction) {
+        let channel = UInt8(clamping: action.targetChannel)
+
+        switch action.actionType {
+        case .mute:
+            sendMIDICC(channel: channel, cc: 85, value: 127)
+        case .solo:
+            sendMIDICC(channel: channel, cc: 86, value: 127)
+        case .selectChannel:
+            sendMIDIProgramChange(channel: 0, program: channel)
+        case .volume:
+            let val = UInt8(clamping: action.parameterValue ?? 100)
+            sendMIDICC(channel: channel, cc: 7, value: val)
+        case .pan:
+            let val = UInt8(clamping: action.parameterValue ?? 64)
+            sendMIDICC(channel: channel, cc: 10, value: val)
+        case .send:
+            let val = UInt8(clamping: action.parameterValue ?? 0)
+            sendMIDICC(channel: channel, cc: 91, value: val)
+        }
+    }
+
+    // MARK: - CoreMIDI 底层操作
+
+    /// 初始化虚拟 MIDI 源
+    ///
+    /// 创建一个名为 "PedalLink Pro" 的虚拟 MIDI 源，
+    /// 其他 MIDI 应用可以将其作为输入源来接收控制信号。
+    private func setupVirtualMIDISource() {
+        let clientStatus = MIDIClientCreate("PedalLinkPro Output" as CFString, nil, nil, &midiClient)
+        guard clientStatus == noErr else { return }
+
+        let sourceStatus = MIDISourceCreateWithProtocol(
+            midiClient,
+            "PedalLink Pro" as CFString,
+            ._1_0,
+            &virtualSource
+        )
+
+        isSetup = sourceStatus == noErr
+    }
+
+    /// 发送 MIDI Control Change 消息
+    /// - Parameters:
+    ///   - channel: MIDI 通道 (0-15)
+    ///   - cc: 控制器编号 (0-127)
+    ///   - value: 控制器值 (0-127)
+    private func sendMIDICC(channel: UInt8, cc: UInt8, value: UInt8) {
+        guard isSetup else { return }
+        let status: UInt8 = 0xB0 | (channel & 0x0F)
+        sendMIDIBytes([status, cc & 0x7F, value & 0x7F])
+    }
+
+    /// 发送 MIDI Program Change 消息
+    /// - Parameters:
+    ///   - channel: MIDI 通道
+    ///   - program: 程序编号
+    private func sendMIDIProgramChange(channel: UInt8, program: UInt8) {
+        guard isSetup else { return }
+        let status: UInt8 = 0xC0 | (channel & 0x0F)
+        sendMIDIBytes([status, program & 0x7F])
+    }
+
+    /// 发送原始 MIDI 字节数据（通过 UMP 封装）
+    /// - Parameter bytes: MIDI 字节数据
+    private func sendMIDIBytes(_ bytes: [UInt8]) {
+        guard isSetup, bytes.count >= 2 else { return }
+
+        var word: UInt32 = 0x20000000
+        word |= UInt32(bytes[0]) << 16
+        word |= UInt32(bytes[1]) << 8
+        if bytes.count > 2 {
+            word |= UInt32(bytes[2])
+        }
+
+        var eventList = MIDIEventList()
+        var packet = MIDIEventListInit(&eventList, ._1_0)
+        packet = MIDIEventListAdd(&eventList, MemoryLayout<MIDIEventList>.size, packet, 0, 1, &word)
+
+        MIDIReceived(virtualSource, &eventList)
+    }
+}

--- a/apps/pedallink-pro/PedalLinkPro/Services/MIDIService.swift
+++ b/apps/pedallink-pro/PedalLinkPro/Services/MIDIService.swift
@@ -1,0 +1,215 @@
+import Foundation
+import CoreMIDI
+import Combine
+
+/// CoreMIDI 服务层，负责 MIDI 设备连接管理和消息接收
+///
+/// 使用 CoreMIDI API 创建 MIDI 客户端，监听所有连接的 MIDI 输入源，
+/// 解析接收到的 MIDI 数据并将其转换为 `MIDIMessage` 模型对象。
+class MIDIService: ObservableObject {
+    /// 当前连接的 MIDI 源设备列表
+    @Published var connectedSources: [MIDISourceInfo] = []
+    /// 是否正在运行
+    @Published var isRunning: Bool = false
+    /// 最近接收的 MIDI 消息（保留最近 100 条）
+    @Published var recentMessages: [MIDIMessage] = []
+    /// 最后一条消息（用于实时显示）
+    @Published var lastMessage: MIDIMessage?
+    /// 错误信息
+    @Published var errorMessage: String?
+
+    /// MIDI 消息回调，供 MappingEngine 使用
+    var onMIDIMessage: ((MIDIMessage) -> Void)?
+
+    private var midiClient: MIDIClientRef = 0
+    private var inputPort: MIDIPortRef = 0
+    private let maxRecentMessages = 100
+
+    /// MIDI 源设备信息
+    struct MIDISourceInfo: Identifiable, Equatable {
+        let id: Int
+        let name: String
+        let endpoint: MIDIEndpointRef
+    }
+
+    /// 启动 MIDI 服务：创建客户端、输入端口并连接所有可用源
+    func start() {
+        let status = MIDIClientCreateWithBlock("PedalLinkPro" as CFString, &midiClient) { [weak self] notification in
+            self?.handleMIDINotification(notification)
+        }
+
+        guard status == noErr else {
+            DispatchQueue.main.async {
+                self.errorMessage = "无法创建 MIDI 客户端 (错误码: \(status))"
+            }
+            return
+        }
+
+        let portStatus = MIDIInputPortCreateWithProtocol(
+            midiClient,
+            "PedalLinkPro Input" as CFString,
+            ._1_0,
+            &inputPort
+        ) { [weak self] eventList, _ in
+            self?.handleMIDIEventList(eventList)
+        }
+
+        guard portStatus == noErr else {
+            DispatchQueue.main.async {
+                self.errorMessage = "无法创建 MIDI 输入端口 (错误码: \(portStatus))"
+            }
+            return
+        }
+
+        connectAllSources()
+
+        DispatchQueue.main.async {
+            self.isRunning = true
+            self.errorMessage = nil
+        }
+    }
+
+    /// 停止 MIDI 服务，释放所有资源
+    func stop() {
+        disconnectAllSources()
+
+        if inputPort != 0 {
+            MIDIPortDispose(inputPort)
+            inputPort = 0
+        }
+        if midiClient != 0 {
+            MIDIClientDispose(midiClient)
+            midiClient = 0
+        }
+
+        DispatchQueue.main.async {
+            self.isRunning = false
+            self.connectedSources = []
+        }
+    }
+
+    /// 刷新设备列表，重新连接所有 MIDI 源
+    func refreshDevices() {
+        disconnectAllSources()
+        connectAllSources()
+    }
+
+    /// 清空消息历史记录
+    func clearMessages() {
+        DispatchQueue.main.async {
+            self.recentMessages = []
+            self.lastMessage = nil
+        }
+    }
+
+    // MARK: - Private Methods
+
+    /// 连接所有可用的 MIDI 源
+    private func connectAllSources() {
+        var sources: [MIDISourceInfo] = []
+        let sourceCount = MIDIGetNumberOfSources()
+
+        for i in 0..<sourceCount {
+            let endpoint = MIDIGetSource(i)
+            let name = getMIDIEndpointName(endpoint)
+
+            MIDIPortConnectSource(inputPort, endpoint, nil)
+            sources.append(MIDISourceInfo(id: i, name: name, endpoint: endpoint))
+        }
+
+        DispatchQueue.main.async {
+            self.connectedSources = sources
+        }
+    }
+
+    /// 断开所有 MIDI 源
+    private func disconnectAllSources() {
+        let sourceCount = MIDIGetNumberOfSources()
+        for i in 0..<sourceCount {
+            let endpoint = MIDIGetSource(i)
+            MIDIPortDisconnectSource(inputPort, endpoint)
+        }
+    }
+
+    /// 处理 MIDI 事件列表（MIDI 1.0 协议）
+    /// - Parameter eventList: 指向 MIDIEventList 的不安全指针
+    private func handleMIDIEventList(_ eventList: UnsafePointer<MIDIEventList>) {
+        let list = eventList.pointee
+        var packet = list.packet
+
+        for _ in 0..<list.numPackets {
+            let words = Mirror(reflecting: packet.words).children.map { $0.value as! UInt32 }
+            if let firstWord = words.first, firstWord != 0 {
+                if let message = parseMIDI1Message(firstWord) {
+                    dispatchMessage(message)
+                }
+            }
+            packet = MIDIEventPacketNext(&packet).pointee
+        }
+    }
+
+    /// 解析 MIDI 1.0 UMP (Universal MIDI Packet) 消息
+    /// - Parameter word: 32位 MIDI 消息字
+    /// - Returns: 解析后的 MIDIMessage，如果不是支持的消息类型则返回 nil
+    private func parseMIDI1Message(_ word: UInt32) -> MIDIMessage? {
+        let messageType = (word >> 20) & 0xF
+        let channel = UInt8((word >> 16) & 0xF)
+        let data1 = UInt8((word >> 8) & 0x7F)
+        let data2 = UInt8(word & 0x7F)
+
+        let type: MIDIMessageType
+        switch messageType {
+        case 0xB: type = .controlChange
+        case 0x9: type = .noteOn
+        case 0x8: type = .noteOff
+        case 0xC: type = .programChange
+        default: return nil
+        }
+
+        return MIDIMessage(
+            timestamp: Date(),
+            type: type,
+            channel: channel,
+            number: data1,
+            value: data2,
+            sourceName: "External"
+        )
+    }
+
+    /// 分发 MIDI 消息到主线程和回调
+    private func dispatchMessage(_ message: MIDIMessage) {
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self else { return }
+            self.lastMessage = message
+            self.recentMessages.insert(message, at: 0)
+            if self.recentMessages.count > self.maxRecentMessages {
+                self.recentMessages.removeLast()
+            }
+        }
+        onMIDIMessage?(message)
+    }
+
+    /// 处理 MIDI 系统通知（设备连接/断开等）
+    private func handleMIDINotification(_ notification: UnsafePointer<MIDINotification>) {
+        switch notification.pointee.messageID {
+        case .msgSetupChanged:
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [weak self] in
+                self?.refreshDevices()
+            }
+        default:
+            break
+        }
+    }
+
+    /// 获取 MIDI 端点的显示名称
+    /// - Parameter endpoint: MIDI 端点引用
+    /// - Returns: 端点名称字符串
+    private func getMIDIEndpointName(_ endpoint: MIDIEndpointRef) -> String {
+        var name: Unmanaged<CFString>?
+        let status = MIDIObjectGetStringProperty(endpoint, kMIDIPropertyDisplayName, &name)
+        if status == noErr, let cfName = name?.takeRetainedValue() {
+            return cfName as String
+        }
+        return "Unknown Device"
+    }
+}

--- a/apps/pedallink-pro/PedalLinkPro/Services/MappingEngine.swift
+++ b/apps/pedallink-pro/PedalLinkPro/Services/MappingEngine.swift
@@ -1,0 +1,203 @@
+import Foundation
+import Combine
+
+/// 映射引擎：核心业务逻辑层
+///
+/// 负责管理所有 MIDI 映射规则，处理传入的 MIDI 消息，
+/// 并根据匹配的映射规则触发相应的宿主操作。
+/// 使用字典索引实现 O(1) 映射查找性能。
+class MappingEngine: ObservableObject {
+    /// 所有映射规则列表
+    @Published var mappings: [MIDIMapping] = []
+    /// 最近触发的映射（用于 UI 高亮）
+    @Published var lastTriggeredMappingId: UUID?
+    /// 各通道的切换状态（mute/solo 等 toggle 状态）
+    @Published var toggleStates: [String: Bool] = [:]
+
+    private let storageKey = "PedalLinkPro_Mappings"
+    private var mappingIndex: [String: [MIDIMapping]] = [:]
+    private let hostInterop = HostInteropService()
+
+    /// 处理传入的 MIDI 消息，查找匹配的映射并执行操作
+    /// - Parameter message: 接收到的 MIDI 消息
+    func process(message: MIDIMessage) {
+        let matchingMappings = findMatchingMappings(for: message)
+
+        for mapping in matchingMappings {
+            executeMapping(mapping, with: message)
+        }
+    }
+
+    /// 根据 MIDI 消息查找所有匹配的映射规则
+    /// - Parameter message: MIDI 消息
+    /// - Returns: 匹配的映射规则数组
+    func findMatchingMappings(for message: MIDIMessage) -> [MIDIMapping] {
+        guard let candidates = mappingIndex[message.matchKey] else { return [] }
+        return candidates.filter { $0.matches(message) }
+    }
+
+    /// 执行映射操作
+    /// - Parameters:
+    ///   - mapping: 匹配的映射规则
+    ///   - message: 触发映射的 MIDI 消息
+    private func executeMapping(_ mapping: MIDIMapping, with message: MIDIMessage) {
+        var action = mapping.action
+
+        if mapping.triggerMode == .toggle {
+            let stateKey = "\(mapping.id)_toggle"
+            let currentState = toggleStates[stateKey] ?? false
+            let newState = !currentState
+
+            DispatchQueue.main.async {
+                self.toggleStates[stateKey] = newState
+            }
+
+            if action.actionType == .volume || action.actionType == .pan || action.actionType == .send {
+                action.parameterValue = newState ? 127 : 0
+            }
+        }
+
+        if mapping.action.actionType == .volume ||
+           mapping.action.actionType == .pan ||
+           mapping.action.actionType == .send {
+            if mapping.triggerMode == .momentary {
+                action.parameterValue = Int(message.value)
+            }
+        }
+
+        hostInterop.execute(action: action)
+
+        DispatchQueue.main.async {
+            self.lastTriggeredMappingId = mapping.id
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+                if self.lastTriggeredMappingId == mapping.id {
+                    self.lastTriggeredMappingId = nil
+                }
+            }
+        }
+    }
+
+    // MARK: - CRUD 操作
+
+    /// 添加新的映射规则
+    /// - Parameter mapping: 要添加的映射规则
+    func addMapping(_ mapping: MIDIMapping) {
+        mappings.append(mapping)
+        rebuildIndex()
+        saveMappings()
+    }
+
+    /// 更新已有的映射规则
+    /// - Parameter mapping: 更新后的映射规则
+    func updateMapping(_ mapping: MIDIMapping) {
+        if let index = mappings.firstIndex(where: { $0.id == mapping.id }) {
+            mappings[index] = mapping
+            rebuildIndex()
+            saveMappings()
+        }
+    }
+
+    /// 删除映射规则
+    /// - Parameter mapping: 要删除的映射规则
+    func deleteMapping(_ mapping: MIDIMapping) {
+        mappings.removeAll { $0.id == mapping.id }
+        rebuildIndex()
+        saveMappings()
+    }
+
+    /// 批量删除映射规则
+    /// - Parameter offsets: 要删除的索引集合
+    func deleteMappings(at offsets: IndexSet) {
+        mappings.remove(atOffsets: offsets)
+        rebuildIndex()
+        saveMappings()
+    }
+
+    /// 移动映射规则顺序
+    /// - Parameters:
+    ///   - source: 源索引集合
+    ///   - destination: 目标索引
+    func moveMappings(from source: IndexSet, to destination: Int) {
+        mappings.move(fromOffsets: source, toOffset: destination)
+        saveMappings()
+    }
+
+    // MARK: - 预设
+
+    /// 创建默认预设映射（适用于常见脚踏板配置）
+    /// - Parameter hostApp: 目标宿主应用
+    /// - Returns: 预设映射规则数组
+    static func createDefaultPreset(for hostApp: HostApp) -> [MIDIMapping] {
+        return [
+            MIDIMapping(
+                name: "脚踏 1 → 通道 1 静音",
+                messageType: .controlChange,
+                midiChannel: 0,
+                controlNumber: 64,
+                triggerMode: .toggle,
+                action: HostAction(hostApp: hostApp, actionType: .mute, targetChannel: 0)
+            ),
+            MIDIMapping(
+                name: "脚踏 2 → 通道 2 静音",
+                messageType: .controlChange,
+                midiChannel: 0,
+                controlNumber: 65,
+                triggerMode: .toggle,
+                action: HostAction(hostApp: hostApp, actionType: .mute, targetChannel: 1)
+            ),
+            MIDIMapping(
+                name: "脚踏 3 → 通道 1 独奏",
+                messageType: .controlChange,
+                midiChannel: 0,
+                controlNumber: 66,
+                triggerMode: .toggle,
+                action: HostAction(hostApp: hostApp, actionType: .solo, targetChannel: 0)
+            ),
+            MIDIMapping(
+                name: "表情踏板 → 通道 1 音量",
+                messageType: .controlChange,
+                midiChannel: 0,
+                controlNumber: 11,
+                triggerMode: .momentary,
+                action: HostAction(hostApp: hostApp, actionType: .volume, targetChannel: 0, parameterValue: 0)
+            ),
+        ]
+    }
+
+    /// 加载默认预设
+    /// - Parameter hostApp: 目标宿主应用
+    func loadPreset(for hostApp: HostApp) {
+        let preset = Self.createDefaultPreset(for: hostApp)
+        mappings.append(contentsOf: preset)
+        rebuildIndex()
+        saveMappings()
+    }
+
+    // MARK: - 持久化
+
+    /// 从 UserDefaults 加载映射规则
+    func loadMappings() {
+        guard let data = UserDefaults.standard.data(forKey: storageKey),
+              let decoded = try? JSONDecoder().decode([MIDIMapping].self, from: data) else {
+            return
+        }
+        mappings = decoded
+        rebuildIndex()
+    }
+
+    /// 保存映射规则到 UserDefaults
+    func saveMappings() {
+        if let encoded = try? JSONEncoder().encode(mappings) {
+            UserDefaults.standard.set(encoded, forKey: storageKey)
+        }
+    }
+
+    /// 重建映射索引以优化查找性能
+    private func rebuildIndex() {
+        mappingIndex = [:]
+        for mapping in mappings where mapping.isEnabled {
+            let key = mapping.matchKey
+            mappingIndex[key, default: []].append(mapping)
+        }
+    }
+}

--- a/apps/pedallink-pro/PedalLinkPro/Services/StoreKitService.swift
+++ b/apps/pedallink-pro/PedalLinkPro/Services/StoreKitService.swift
@@ -1,0 +1,146 @@
+import Foundation
+import StoreKit
+
+/// StoreKit 服务层：管理应用内购买（一次性买断）
+///
+/// PedalLink Pro 使用一次性购买模式 ($9.99)，
+/// 购买后解锁全部功能，终身免费更新。
+class StoreKitService: ObservableObject {
+    /// 是否已解锁专业版
+    @Published var isProUnlocked: Bool = false
+    /// 可用的产品列表
+    @Published var products: [Product] = []
+    /// 购买状态
+    @Published var purchaseState: PurchaseState = .idle
+    /// 错误消息
+    @Published var errorMessage: String?
+
+    /// 购买状态枚举
+    enum PurchaseState {
+        case idle
+        case purchasing
+        case purchased
+        case failed
+        case restored
+    }
+
+    /// 产品标识符
+    static let proProductId = "com.pedallinkpro.unlock"
+
+    private var transactionListener: Task<Void, Error>?
+
+    init() {
+        transactionListener = listenForTransactions()
+        Task {
+            await checkExistingPurchases()
+            await loadProducts()
+        }
+    }
+
+    deinit {
+        transactionListener?.cancel()
+    }
+
+    /// 加载可用产品
+    @MainActor
+    func loadProducts() async {
+        do {
+            let storeProducts = try await Product.products(for: [Self.proProductId])
+            products = storeProducts
+        } catch {
+            errorMessage = "无法加载产品信息: \(error.localizedDescription)"
+        }
+    }
+
+    /// 执行购买
+    /// - Parameter product: 要购买的产品
+    @MainActor
+    func purchase(_ product: Product) async {
+        purchaseState = .purchasing
+
+        do {
+            let result = try await product.purchase()
+
+            switch result {
+            case .success(let verification):
+                let transaction = try checkVerified(verification)
+                await transaction.finish()
+                isProUnlocked = true
+                purchaseState = .purchased
+
+            case .pending:
+                purchaseState = .idle
+
+            case .userCancelled:
+                purchaseState = .idle
+
+            @unknown default:
+                purchaseState = .failed
+            }
+        } catch {
+            errorMessage = "购买失败: \(error.localizedDescription)"
+            purchaseState = .failed
+        }
+    }
+
+    /// 恢复购买
+    @MainActor
+    func restorePurchases() async {
+        do {
+            try await AppStore.sync()
+            await checkExistingPurchases()
+            if isProUnlocked {
+                purchaseState = .restored
+            }
+        } catch {
+            errorMessage = "恢复购买失败: \(error.localizedDescription)"
+            purchaseState = .failed
+        }
+    }
+
+    /// 专业版价格显示字符串
+    var proPriceString: String {
+        products.first?.displayPrice ?? "$9.99"
+    }
+
+    // MARK: - Private
+
+    /// 验证交易签名
+    private func checkVerified<T>(_ result: VerificationResult<T>) throws -> T {
+        switch result {
+        case .unverified(_, let error):
+            throw error
+        case .verified(let safe):
+            return safe
+        }
+    }
+
+    /// 检查已有购买记录
+    @MainActor
+    private func checkExistingPurchases() async {
+        for await result in Transaction.currentEntitlements {
+            if case .verified(let transaction) = result {
+                if transaction.productID == Self.proProductId {
+                    isProUnlocked = true
+                    return
+                }
+            }
+        }
+    }
+
+    /// 监听交易更新（处理中断购买、家庭共享等场景）
+    private func listenForTransactions() -> Task<Void, Error> {
+        return Task.detached {
+            for await result in Transaction.updates {
+                if case .verified(let transaction) = result {
+                    if transaction.productID == Self.proProductId {
+                        await MainActor.run {
+                            self.isProUnlocked = true
+                        }
+                    }
+                    await transaction.finish()
+                }
+            }
+        }
+    }
+}

--- a/apps/pedallink-pro/PedalLinkPro/Utilities/Constants.swift
+++ b/apps/pedallink-pro/PedalLinkPro/Utilities/Constants.swift
@@ -1,0 +1,46 @@
+import SwiftUI
+
+/// 应用常量定义
+enum AppConstants {
+    /// 应用名称
+    static let appName = "PedalLink Pro"
+    /// 应用版本
+    static let appVersion = "1.0.0"
+    /// 最大映射数量（免费版限制）
+    static let freeMaxMappings = 3
+    /// 最大 MIDI 通道数
+    static let maxMIDIChannels = 16
+    /// 最大通道数
+    static let maxHostChannels = 32
+}
+
+/// 设计系统颜色
+enum AppColors {
+    static let primary = Color("AccentColor")
+    static let midiActive = Color.green
+    static let midiInactive = Color.gray.opacity(0.3)
+    static let muteRed = Color.red
+    static let soloYellow = Color.yellow
+    static let channelBlue = Color.blue
+    static let background = Color(UIColor.systemBackground)
+    static let secondaryBackground = Color(UIColor.secondarySystemBackground)
+    static let cardBackground = Color(UIColor.tertiarySystemBackground)
+}
+
+/// 触感反馈管理器
+enum HapticManager {
+    /// 触发轻量级触感
+    static func light() {
+        UIImpactFeedbackGenerator(style: .light).impactOccurred()
+    }
+
+    /// 触发中量级触感
+    static func medium() {
+        UIImpactFeedbackGenerator(style: .medium).impactOccurred()
+    }
+
+    /// 触发通知触感
+    static func notification(_ type: UINotificationFeedbackGenerator.FeedbackType) {
+        UINotificationFeedbackGenerator().notificationOccurred(type)
+    }
+}

--- a/apps/pedallink-pro/PedalLinkPro/ViewModels/MIDIMonitorViewModel.swift
+++ b/apps/pedallink-pro/PedalLinkPro/ViewModels/MIDIMonitorViewModel.swift
@@ -1,0 +1,41 @@
+import Foundation
+import Combine
+
+/// MIDI 监视器视图模型
+///
+/// 管理 MIDI 监视器视图的状态和过滤逻辑，
+/// 提供实时消息流的过滤和搜索功能。
+class MIDIMonitorViewModel: ObservableObject {
+    /// 消息类型过滤器
+    @Published var filterType: MIDIMessageType? = nil
+    /// 通道过滤器 (-1 表示全部)
+    @Published var filterChannel: Int = -1
+    /// 是否暂停更新
+    @Published var isPaused: Bool = false
+    /// 是否显示 MIDI 学习模式
+    @Published var isLearning: Bool = false
+    /// MIDI 学习回调
+    var onLearnedMessage: ((MIDIMessage) -> Void)?
+
+    /// 过滤消息列表
+    /// - Parameter messages: 原始消息列表
+    /// - Returns: 过滤后的消息列表
+    func filteredMessages(_ messages: [MIDIMessage]) -> [MIDIMessage] {
+        messages.filter { message in
+            if let type = filterType, message.type != type {
+                return false
+            }
+            if filterChannel >= 0 && message.channel != UInt8(filterChannel) {
+                return false
+            }
+            return true
+        }
+    }
+
+    /// 处理 MIDI 学习模式下收到的消息
+    /// - Parameter message: 学习到的 MIDI 消息
+    func handleLearnedMessage(_ message: MIDIMessage) {
+        isLearning = false
+        onLearnedMessage?(message)
+    }
+}

--- a/apps/pedallink-pro/PedalLinkPro/ViewModels/MappingListViewModel.swift
+++ b/apps/pedallink-pro/PedalLinkPro/ViewModels/MappingListViewModel.swift
@@ -1,0 +1,38 @@
+import Foundation
+import Combine
+
+/// 映射列表视图模型
+class MappingListViewModel: ObservableObject {
+    /// 是否显示新建映射弹窗
+    @Published var showingAddSheet: Bool = false
+    /// 是否显示预设选择器
+    @Published var showingPresetPicker: Bool = false
+    /// 搜索文本
+    @Published var searchText: String = ""
+    /// 当前选中的映射（用于编辑）
+    @Published var selectedMapping: MIDIMapping?
+
+    /// 根据搜索文本过滤映射列表
+    /// - Parameter mappings: 原始映射列表
+    /// - Returns: 过滤后的列表
+    func filteredMappings(_ mappings: [MIDIMapping]) -> [MIDIMapping] {
+        guard !searchText.isEmpty else { return mappings }
+        return mappings.filter { mapping in
+            mapping.name.localizedCaseInsensitiveContains(searchText) ||
+            mapping.action.displayString.localizedCaseInsensitiveContains(searchText)
+        }
+    }
+
+    /// 创建新映射模板
+    /// - Returns: 预填充的新映射规则
+    func createNewMapping() -> MIDIMapping {
+        MIDIMapping(
+            name: "新映射 \(Date().formatted(date: .omitted, time: .shortened))",
+            action: HostAction(
+                hostApp: .aum,
+                actionType: .mute,
+                targetChannel: 0
+            )
+        )
+    }
+}

--- a/apps/pedallink-pro/PedalLinkPro/Views/Components/ActionPickerView.swift
+++ b/apps/pedallink-pro/PedalLinkPro/Views/Components/ActionPickerView.swift
@@ -1,0 +1,57 @@
+import SwiftUI
+
+/// 操作类型选择器视图
+///
+/// 以网格形式展示可用的通道操作类型，
+/// 每个操作带有图标和描述。
+struct ActionPickerView: View {
+    @Binding var selectedAction: ChannelActionType
+    let columns = Array(repeating: GridItem(.flexible(), spacing: 12), count: 3)
+
+    var body: some View {
+        LazyVGrid(columns: columns, spacing: 12) {
+            ForEach(ChannelActionType.allCases) { action in
+                ActionCard(
+                    action: action,
+                    isSelected: selectedAction == action
+                ) {
+                    selectedAction = action
+                    HapticManager.light()
+                }
+            }
+        }
+        .padding()
+    }
+}
+
+/// 操作卡片组件
+struct ActionCard: View {
+    let action: ChannelActionType
+    let isSelected: Bool
+    let onTap: () -> Void
+
+    var body: some View {
+        Button(action: onTap) {
+            VStack(spacing: 8) {
+                Image(systemName: action.iconName)
+                    .font(.title2)
+                    .foregroundColor(isSelected ? .white : .orange)
+
+                Text(action.rawValue)
+                    .font(.caption)
+                    .fontWeight(.medium)
+                    .foregroundColor(isSelected ? .white : .primary)
+            }
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 16)
+            .background(
+                RoundedRectangle(cornerRadius: 12)
+                    .fill(isSelected ? Color.orange : AppColors.cardBackground)
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 12)
+                    .stroke(isSelected ? Color.orange : Color.clear, lineWidth: 2)
+            )
+        }
+    }
+}

--- a/apps/pedallink-pro/PedalLinkPro/Views/Components/MIDIActivityIndicator.swift
+++ b/apps/pedallink-pro/PedalLinkPro/Views/Components/MIDIActivityIndicator.swift
@@ -1,0 +1,41 @@
+import SwiftUI
+
+/// MIDI 信号活动指示器
+///
+/// 在接收到 MIDI 消息时闪烁，提供直观的实时反馈。
+struct MIDIActivityIndicator: View {
+    let message: MIDIMessage
+    @State private var isAnimating = false
+
+    var body: some View {
+        HStack(spacing: 4) {
+            Circle()
+                .fill(colorForType(message.type))
+                .frame(width: 6, height: 6)
+                .scaleEffect(isAnimating ? 1.5 : 1.0)
+                .opacity(isAnimating ? 1.0 : 0.5)
+
+            Text(message.type.rawValue)
+                .font(.system(size: 9, weight: .medium, design: .monospaced))
+                .foregroundColor(.secondary)
+        }
+        .onChange(of: message.id) { _, _ in
+            withAnimation(.easeOut(duration: 0.15)) {
+                isAnimating = true
+            }
+            withAnimation(.easeIn(duration: 0.3).delay(0.15)) {
+                isAnimating = false
+            }
+        }
+    }
+
+    /// 根据消息类型返回颜色
+    private func colorForType(_ type: MIDIMessageType) -> Color {
+        switch type {
+        case .controlChange: return .orange
+        case .noteOn: return .green
+        case .noteOff: return .red
+        case .programChange: return .blue
+        }
+    }
+}

--- a/apps/pedallink-pro/PedalLinkPro/Views/Components/PedalButton.swift
+++ b/apps/pedallink-pro/PedalLinkPro/Views/Components/PedalButton.swift
@@ -1,0 +1,72 @@
+import SwiftUI
+
+/// 踏板按钮组件
+///
+/// 模拟物理脚踏板外观的圆形按钮，用于 UI 测试和虚拟触发。
+/// 支持按下/释放动画和触感反馈。
+struct PedalButton: View {
+    let title: String
+    let subtitle: String
+    let isActive: Bool
+    let color: Color
+    let action: () -> Void
+
+    @State private var isPressed = false
+
+    var body: some View {
+        Button(action: {
+            HapticManager.medium()
+            action()
+        }) {
+            VStack(spacing: 6) {
+                ZStack {
+                    Circle()
+                        .fill(
+                            RadialGradient(
+                                gradient: Gradient(colors: [
+                                    color.opacity(isActive ? 0.8 : 0.3),
+                                    color.opacity(isActive ? 0.4 : 0.1)
+                                ]),
+                                center: .center,
+                                startRadius: 5,
+                                endRadius: 35
+                            )
+                        )
+                        .frame(width: 70, height: 70)
+                        .overlay(
+                            Circle()
+                                .stroke(color.opacity(isActive ? 1.0 : 0.3), lineWidth: 2)
+                        )
+                        .shadow(
+                            color: isActive ? color.opacity(0.6) : .clear,
+                            radius: 10
+                        )
+                        .scaleEffect(isPressed ? 0.92 : 1.0)
+
+                    Image(systemName: isActive ? "power.circle.fill" : "power.circle")
+                        .font(.title2)
+                        .foregroundColor(isActive ? .white : color.opacity(0.5))
+                }
+
+                Text(title)
+                    .font(.caption2)
+                    .fontWeight(.medium)
+                    .foregroundColor(.primary)
+
+                Text(subtitle)
+                    .font(.system(size: 9))
+                    .foregroundColor(.secondary)
+            }
+        }
+        .buttonStyle(PedalButtonStyle())
+    }
+}
+
+/// 踏板按钮样式（处理按下效果）
+struct PedalButtonStyle: ButtonStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .scaleEffect(configuration.isPressed ? 0.95 : 1.0)
+            .animation(.easeInOut(duration: 0.1), value: configuration.isPressed)
+    }
+}

--- a/apps/pedallink-pro/PedalLinkPro/Views/ContentView.swift
+++ b/apps/pedallink-pro/PedalLinkPro/Views/ContentView.swift
@@ -1,0 +1,32 @@
+import SwiftUI
+
+/// 主内容视图，使用 TabView 组织三个核心页面
+struct ContentView: View {
+    @EnvironmentObject var midiService: MIDIService
+    @EnvironmentObject var mappingEngine: MappingEngine
+    @EnvironmentObject var storeService: StoreKitService
+    @State private var selectedTab = 0
+
+    var body: some View {
+        TabView(selection: $selectedTab) {
+            MIDIMonitorView()
+                .tabItem {
+                    Label("监视器", systemImage: "waveform")
+                }
+                .tag(0)
+
+            MappingListView()
+                .tabItem {
+                    Label("映射", systemImage: "arrow.triangle.swap")
+                }
+                .tag(1)
+
+            SettingsView()
+                .tabItem {
+                    Label("设置", systemImage: "gearshape.fill")
+                }
+                .tag(2)
+        }
+        .tint(.orange)
+    }
+}

--- a/apps/pedallink-pro/PedalLinkPro/Views/MIDIMonitorView.swift
+++ b/apps/pedallink-pro/PedalLinkPro/Views/MIDIMonitorView.swift
@@ -1,0 +1,193 @@
+import SwiftUI
+
+/// MIDI 监视器视图
+///
+/// 实时显示所有接收到的 MIDI 消息，支持过滤和 MIDI 学习模式。
+/// 用于调试脚踏板连接和查看传入的 MIDI CC 数据。
+struct MIDIMonitorView: View {
+    @EnvironmentObject var midiService: MIDIService
+    @StateObject private var viewModel = MIDIMonitorViewModel()
+
+    var body: some View {
+        NavigationStack {
+            VStack(spacing: 0) {
+                connectionStatusBar
+                filterBar
+                messageList
+            }
+            .navigationTitle("MIDI 监视器")
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    HStack(spacing: 12) {
+                        Button {
+                            viewModel.isPaused.toggle()
+                        } label: {
+                            Image(systemName: viewModel.isPaused ? "play.fill" : "pause.fill")
+                        }
+
+                        Button {
+                            midiService.clearMessages()
+                        } label: {
+                            Image(systemName: "trash")
+                        }
+
+                        Button {
+                            midiService.refreshDevices()
+                        } label: {
+                            Image(systemName: "arrow.clockwise")
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /// 设备连接状态栏
+    private var connectionStatusBar: some View {
+        HStack {
+            Circle()
+                .fill(midiService.isRunning ? AppColors.midiActive : AppColors.muteRed)
+                .frame(width: 8, height: 8)
+
+            Text(midiService.isRunning ? "已连接" : "未连接")
+                .font(.caption)
+                .foregroundColor(.secondary)
+
+            Spacer()
+
+            if midiService.connectedSources.isEmpty {
+                Text("未检测到 MIDI 设备")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            } else {
+                Text("\(midiService.connectedSources.count) 个设备")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+
+            if let lastMsg = midiService.lastMessage {
+                MIDIActivityIndicator(message: lastMsg)
+            }
+        }
+        .padding(.horizontal)
+        .padding(.vertical, 8)
+        .background(AppColors.secondaryBackground)
+    }
+
+    /// 消息过滤栏
+    private var filterBar: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 8) {
+                FilterChip(
+                    title: "全部",
+                    isSelected: viewModel.filterType == nil,
+                    action: { viewModel.filterType = nil }
+                )
+                ForEach(MIDIMessageType.allCases, id: \.self) { type in
+                    FilterChip(
+                        title: type.rawValue,
+                        isSelected: viewModel.filterType == type,
+                        action: { viewModel.filterType = type }
+                    )
+                }
+            }
+            .padding(.horizontal)
+            .padding(.vertical, 8)
+        }
+        .background(AppColors.secondaryBackground.opacity(0.5))
+    }
+
+    /// 消息列表
+    private var messageList: some View {
+        Group {
+            if midiService.recentMessages.isEmpty {
+                emptyState
+            } else {
+                let filtered = viewModel.filteredMessages(midiService.recentMessages)
+                List(filtered) { message in
+                    MIDIMessageRow(message: message)
+                        .listRowBackground(Color.clear)
+                }
+                .listStyle(.plain)
+            }
+        }
+    }
+
+    /// 空状态视图
+    private var emptyState: some View {
+        VStack(spacing: 16) {
+            Spacer()
+            Image(systemName: "pianokeys")
+                .font(.system(size: 64))
+                .foregroundColor(.secondary.opacity(0.5))
+            Text("等待 MIDI 信号...")
+                .font(.title3)
+                .foregroundColor(.secondary)
+            Text("连接 MIDI 脚踏板并踩下踏板\n信号将在此处实时显示")
+                .font(.caption)
+                .foregroundColor(.secondary.opacity(0.7))
+                .multilineTextAlignment(.center)
+            Spacer()
+        }
+    }
+}
+
+/// MIDI 消息行视图
+struct MIDIMessageRow: View {
+    let message: MIDIMessage
+
+    var body: some View {
+        HStack(spacing: 12) {
+            RoundedRectangle(cornerRadius: 4)
+                .fill(colorForType(message.type))
+                .frame(width: 4, height: 36)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(message.displayString)
+                    .font(.system(.body, design: .monospaced))
+                    .foregroundColor(.primary)
+
+                Text(message.sourceName)
+                    .font(.caption2)
+                    .foregroundColor(.secondary)
+            }
+
+            Spacer()
+
+            Text(message.timestamp, style: .time)
+                .font(.caption2)
+                .foregroundColor(.secondary)
+        }
+        .padding(.vertical, 4)
+    }
+
+    /// 根据消息类型返回对应颜色
+    private func colorForType(_ type: MIDIMessageType) -> Color {
+        switch type {
+        case .controlChange: return .orange
+        case .noteOn: return .green
+        case .noteOff: return .red
+        case .programChange: return .blue
+        }
+    }
+}
+
+/// 过滤标签组件
+struct FilterChip: View {
+    let title: String
+    let isSelected: Bool
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            Text(title)
+                .font(.caption)
+                .fontWeight(isSelected ? .semibold : .regular)
+                .padding(.horizontal, 12)
+                .padding(.vertical, 6)
+                .background(isSelected ? Color.orange : AppColors.cardBackground)
+                .foregroundColor(isSelected ? .black : .secondary)
+                .cornerRadius(16)
+        }
+    }
+}

--- a/apps/pedallink-pro/PedalLinkPro/Views/MappingDetailView.swift
+++ b/apps/pedallink-pro/PedalLinkPro/Views/MappingDetailView.swift
@@ -1,0 +1,216 @@
+import SwiftUI
+
+/// 映射详情/编辑视图
+///
+/// 用于创建新映射或编辑已有映射规则。
+/// 支持 MIDI Learn（学习模式）自动捕获脚踏板信号。
+struct MappingDetailView: View {
+    @EnvironmentObject var mappingEngine: MappingEngine
+    @EnvironmentObject var midiService: MIDIService
+    @Environment(\.dismiss) private var dismiss
+
+    @State var mapping: MIDIMapping
+    let isNew: Bool
+
+    @State private var isLearning = false
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                basicSection
+                midiInputSection
+                actionSection
+                triggerSection
+
+                if !isNew {
+                    deleteSection
+                }
+            }
+            .navigationTitle(isNew ? "新建映射" : "编辑映射")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarLeading) {
+                    Button("取消") { dismiss() }
+                }
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button("保存") { save() }
+                        .fontWeight(.semibold)
+                }
+            }
+        }
+    }
+
+    /// 基本信息区域
+    private var basicSection: some View {
+        Section("基本信息") {
+            TextField("映射名称", text: $mapping.name)
+            Toggle("启用", isOn: $mapping.isEnabled)
+        }
+    }
+
+    /// MIDI 输入配置区域
+    private var midiInputSection: some View {
+        Section {
+            Picker("消息类型", selection: $mapping.messageType) {
+                ForEach(MIDIMessageType.allCases, id: \.self) { type in
+                    Text(type.rawValue).tag(type)
+                }
+            }
+
+            Picker("MIDI 通道", selection: $mapping.midiChannel) {
+                ForEach(0..<16, id: \.self) { ch in
+                    Text("通道 \(ch + 1)").tag(UInt8(ch))
+                }
+            }
+
+            HStack {
+                Text("控制器编号")
+                Spacer()
+                Text("\(mapping.controlNumber)")
+                    .foregroundColor(.orange)
+                    .font(.system(.body, design: .monospaced))
+                Stepper("", value: $mapping.controlNumber, in: 0...127)
+                    .labelsHidden()
+            }
+
+            Button {
+                startLearning()
+            } label: {
+                HStack {
+                    Image(systemName: isLearning ? "antenna.radiowaves.left.and.right" : "graduationcap.fill")
+                    Text(isLearning ? "等待 MIDI 输入..." : "MIDI 学习")
+                    if isLearning {
+                        Spacer()
+                        ProgressView()
+                    }
+                }
+            }
+            .foregroundColor(.orange)
+        } header: {
+            Text("MIDI 输入")
+        } footer: {
+            Text("使用 MIDI 学习模式可自动识别脚踏板信号")
+        }
+    }
+
+    /// 目标操作配置区域
+    private var actionSection: some View {
+        Section("目标操作") {
+            Picker("宿主应用", selection: $mapping.action.hostApp) {
+                ForEach(HostApp.allCases) { app in
+                    Text(app.rawValue).tag(app)
+                }
+            }
+
+            Picker("操作类型", selection: $mapping.action.actionType) {
+                ForEach(ChannelActionType.allCases) { action in
+                    Label(action.rawValue, systemImage: action.iconName)
+                        .tag(action)
+                }
+            }
+
+            Picker("目标通道", selection: $mapping.action.targetChannel) {
+                ForEach(0..<AppConstants.maxHostChannels, id: \.self) { ch in
+                    Text("通道 \(ch + 1)").tag(ch)
+                }
+            }
+
+            if mapping.action.actionType == .volume ||
+               mapping.action.actionType == .pan ||
+               mapping.action.actionType == .send {
+                let paramBinding = Binding<Double>(
+                    get: { Double(mapping.action.parameterValue ?? 64) },
+                    set: { mapping.action.parameterValue = Int($0) }
+                )
+                VStack(alignment: .leading) {
+                    Text("参数值: \(mapping.action.parameterValue ?? 64)")
+                        .font(.caption)
+                    Slider(value: paramBinding, in: 0...127, step: 1)
+                        .tint(.orange)
+                }
+            }
+        }
+    }
+
+    /// 触发模式配置区域
+    private var triggerSection: some View {
+        Section {
+            Picker("触发模式", selection: $mapping.triggerMode) {
+                ForEach(TriggerMode.allCases) { mode in
+                    Text(mode.rawValue).tag(mode)
+                }
+            }
+
+            if mapping.triggerMode != .momentary {
+                HStack {
+                    Text("触发阈值")
+                    Spacer()
+                    Text("\(mapping.thresholdValue)")
+                        .foregroundColor(.orange)
+                        .font(.system(.body, design: .monospaced))
+                    Stepper("", value: $mapping.thresholdValue, in: 1...127)
+                        .labelsHidden()
+                }
+            }
+        } header: {
+            Text("触发设置")
+        } footer: {
+            Text(triggerModeDescription)
+        }
+    }
+
+    /// 删除区域
+    private var deleteSection: some View {
+        Section {
+            Button(role: .destructive) {
+                mappingEngine.deleteMapping(mapping)
+                dismiss()
+            } label: {
+                HStack {
+                    Spacer()
+                    Label("删除映射", systemImage: "trash")
+                    Spacer()
+                }
+            }
+        }
+    }
+
+    /// 触发模式说明文字
+    private var triggerModeDescription: String {
+        switch mapping.triggerMode {
+        case .onPress: return "当 MIDI 值 ≥ 阈值时触发（适合单次踩下）"
+        case .onRelease: return "当 MIDI 值 < 阈值时触发（适合释放踏板）"
+        case .toggle: return "每次踩下切换状态（适合静音/独奏开关）"
+        case .momentary: return "持续跟踪值变化（适合表情踏板/音量控制）"
+        }
+    }
+
+    /// 开始 MIDI 学习模式
+    private func startLearning() {
+        isLearning = true
+        HapticManager.light()
+
+        let originalCallback = midiService.onMIDIMessage
+        midiService.onMIDIMessage = { [self] message in
+            DispatchQueue.main.async {
+                self.mapping.messageType = message.type
+                self.mapping.midiChannel = message.channel
+                self.mapping.controlNumber = message.number
+                self.isLearning = false
+                HapticManager.notification(.success)
+            }
+            midiService.onMIDIMessage = originalCallback
+        }
+    }
+
+    /// 保存映射
+    private func save() {
+        if isNew {
+            mappingEngine.addMapping(mapping)
+        } else {
+            mappingEngine.updateMapping(mapping)
+        }
+        HapticManager.notification(.success)
+        dismiss()
+    }
+}

--- a/apps/pedallink-pro/PedalLinkPro/Views/MappingListView.swift
+++ b/apps/pedallink-pro/PedalLinkPro/Views/MappingListView.swift
@@ -1,0 +1,223 @@
+import SwiftUI
+
+/// 映射列表视图
+///
+/// 显示所有已创建的 MIDI 映射规则，支持新建、编辑、删除和排序。
+/// 实时高亮当前被触发的映射。
+struct MappingListView: View {
+    @EnvironmentObject var mappingEngine: MappingEngine
+    @EnvironmentObject var storeService: StoreKitService
+    @StateObject private var viewModel = MappingListViewModel()
+
+    var body: some View {
+        NavigationStack {
+            Group {
+                if mappingEngine.mappings.isEmpty {
+                    emptyState
+                } else {
+                    mappingList
+                }
+            }
+            .navigationTitle("映射规则")
+            .searchable(text: $viewModel.searchText, prompt: "搜索映射...")
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    HStack(spacing: 12) {
+                        Menu {
+                            Button("加载 AUM 预设") {
+                                mappingEngine.loadPreset(for: .aum)
+                            }
+                            Button("加载 Audiobus 预设") {
+                                mappingEngine.loadPreset(for: .audiobus)
+                            }
+                            Button("加载通用预设") {
+                                mappingEngine.loadPreset(for: .generic)
+                            }
+                        } label: {
+                            Image(systemName: "tray.and.arrow.down.fill")
+                        }
+
+                        Button {
+                            if canAddMapping {
+                                viewModel.showingAddSheet = true
+                            }
+                        } label: {
+                            Image(systemName: "plus")
+                        }
+                    }
+                }
+            }
+            .sheet(isPresented: $viewModel.showingAddSheet) {
+                MappingDetailView(
+                    mapping: viewModel.createNewMapping(),
+                    isNew: true
+                )
+            }
+            .sheet(item: $viewModel.selectedMapping) { mapping in
+                MappingDetailView(
+                    mapping: mapping,
+                    isNew: false
+                )
+            }
+        }
+    }
+
+    /// 是否可以添加映射（免费版限制）
+    private var canAddMapping: Bool {
+        storeService.isProUnlocked || mappingEngine.mappings.count < AppConstants.freeMaxMappings
+    }
+
+    /// 映射列表
+    private var mappingList: some View {
+        List {
+            if !canAddMapping {
+                freeVersionBanner
+            }
+
+            ForEach(viewModel.filteredMappings(mappingEngine.mappings)) { mapping in
+                MappingRowView(
+                    mapping: mapping,
+                    isTriggered: mappingEngine.lastTriggeredMappingId == mapping.id,
+                    toggleState: mappingEngine.toggleStates["\(mapping.id)_toggle"] ?? false
+                )
+                .contentShape(Rectangle())
+                .onTapGesture {
+                    viewModel.selectedMapping = mapping
+                }
+            }
+            .onDelete { offsets in
+                mappingEngine.deleteMappings(at: offsets)
+            }
+            .onMove { source, destination in
+                mappingEngine.moveMappings(from: source, to: destination)
+            }
+        }
+        .listStyle(.insetGrouped)
+    }
+
+    /// 免费版限制提示
+    private var freeVersionBanner: some View {
+        HStack {
+            Image(systemName: "lock.fill")
+                .foregroundColor(.orange)
+            VStack(alignment: .leading) {
+                Text("免费版限制 \(AppConstants.freeMaxMappings) 个映射")
+                    .font(.caption)
+                    .fontWeight(.medium)
+                Text("升级 Pro 解锁无限映射")
+                    .font(.caption2)
+                    .foregroundColor(.secondary)
+            }
+            Spacer()
+            Button("升级") {
+                if let product = storeService.products.first {
+                    Task { await storeService.purchase(product) }
+                }
+            }
+            .buttonStyle(.borderedProminent)
+            .tint(.orange)
+            .controlSize(.small)
+        }
+        .padding(.vertical, 4)
+    }
+
+    /// 空状态视图
+    private var emptyState: some View {
+        VStack(spacing: 20) {
+            Spacer()
+            Image(systemName: "arrow.triangle.swap")
+                .font(.system(size: 64))
+                .foregroundColor(.secondary.opacity(0.5))
+            Text("暂无映射规则")
+                .font(.title3)
+                .foregroundColor(.secondary)
+            Text("创建映射将脚踏板信号\n关联到宿主软件操作")
+                .font(.caption)
+                .foregroundColor(.secondary.opacity(0.7))
+                .multilineTextAlignment(.center)
+
+            VStack(spacing: 12) {
+                Button {
+                    viewModel.showingAddSheet = true
+                } label: {
+                    Label("新建映射", systemImage: "plus.circle.fill")
+                        .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.borderedProminent)
+                .tint(.orange)
+
+                Button {
+                    mappingEngine.loadPreset(for: .aum)
+                } label: {
+                    Label("加载 AUM 预设", systemImage: "tray.and.arrow.down")
+                        .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.bordered)
+            }
+            .padding(.horizontal, 40)
+
+            Spacer()
+        }
+    }
+}
+
+/// 映射行视图
+struct MappingRowView: View {
+    let mapping: MIDIMapping
+    let isTriggered: Bool
+    let toggleState: Bool
+
+    var body: some View {
+        HStack(spacing: 12) {
+            Circle()
+                .fill(mapping.isEnabled ? (isTriggered ? .green : .orange) : .gray)
+                .frame(width: 10, height: 10)
+                .scaleEffect(isTriggered ? 1.5 : 1.0)
+                .animation(.easeInOut(duration: 0.15), value: isTriggered)
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text(mapping.name)
+                    .font(.body)
+                    .fontWeight(.medium)
+                    .foregroundColor(mapping.isEnabled ? .primary : .secondary)
+
+                HStack(spacing: 6) {
+                    Label(
+                        "\(mapping.messageType.rawValue) \(mapping.controlNumber)",
+                        systemImage: "pianokeys"
+                    )
+                    .font(.caption2)
+                    .foregroundColor(.orange)
+
+                    Image(systemName: "arrow.right")
+                        .font(.caption2)
+                        .foregroundColor(.secondary)
+
+                    Label(
+                        mapping.action.displayString,
+                        systemImage: mapping.action.actionType.iconName
+                    )
+                    .font(.caption2)
+                    .foregroundColor(.secondary)
+                }
+            }
+
+            Spacer()
+
+            if mapping.triggerMode == .toggle {
+                Circle()
+                    .fill(toggleState ? AppColors.midiActive : AppColors.midiInactive)
+                    .frame(width: 12, height: 12)
+            }
+
+            Image(systemName: "chevron.right")
+                .font(.caption)
+                .foregroundColor(.secondary)
+        }
+        .padding(.vertical, 4)
+        .background(
+            RoundedRectangle(cornerRadius: 8)
+                .fill(isTriggered ? Color.green.opacity(0.1) : Color.clear)
+        )
+    }
+}

--- a/apps/pedallink-pro/PedalLinkPro/Views/SettingsView.swift
+++ b/apps/pedallink-pro/PedalLinkPro/Views/SettingsView.swift
@@ -1,0 +1,168 @@
+import SwiftUI
+
+/// 设置视图
+///
+/// 提供应用设置、设备管理、购买管理和关于信息。
+struct SettingsView: View {
+    @EnvironmentObject var midiService: MIDIService
+    @EnvironmentObject var storeService: StoreKitService
+    @AppStorage("hapticFeedback") private var hapticFeedback = true
+    @AppStorage("autoConnect") private var autoConnect = true
+    @AppStorage("showMIDIValues") private var showMIDIValues = true
+
+    var body: some View {
+        NavigationStack {
+            List {
+                deviceSection
+                proSection
+                preferencesSection
+                aboutSection
+            }
+            .navigationTitle("设置")
+        }
+    }
+
+    /// 设备管理
+    private var deviceSection: some View {
+        Section("MIDI 设备") {
+            HStack {
+                Image(systemName: midiService.isRunning ? "checkmark.circle.fill" : "xmark.circle.fill")
+                    .foregroundColor(midiService.isRunning ? .green : .red)
+                Text("MIDI 服务")
+                Spacer()
+                Text(midiService.isRunning ? "运行中" : "已停止")
+                    .foregroundColor(.secondary)
+            }
+
+            ForEach(midiService.connectedSources) { source in
+                HStack {
+                    Image(systemName: "cable.connector")
+                        .foregroundColor(.orange)
+                    Text(source.name)
+                    Spacer()
+                    Image(systemName: "checkmark")
+                        .foregroundColor(.green)
+                        .font(.caption)
+                }
+            }
+
+            if midiService.connectedSources.isEmpty {
+                HStack {
+                    Image(systemName: "exclamationmark.triangle")
+                        .foregroundColor(.yellow)
+                    Text("未检测到 MIDI 设备")
+                        .foregroundColor(.secondary)
+                }
+            }
+
+            Button {
+                midiService.refreshDevices()
+            } label: {
+                Label("刷新设备", systemImage: "arrow.clockwise")
+            }
+
+            Toggle("自动连接新设备", isOn: $autoConnect)
+        }
+    }
+
+    /// Pro 版购买
+    private var proSection: some View {
+        Section {
+            if storeService.isProUnlocked {
+                HStack {
+                    Image(systemName: "crown.fill")
+                        .foregroundColor(.orange)
+                    Text("Pro 已解锁")
+                        .fontWeight(.medium)
+                    Spacer()
+                    Text("感谢支持！")
+                        .foregroundColor(.secondary)
+                        .font(.caption)
+                }
+            } else {
+                VStack(alignment: .leading, spacing: 8) {
+                    HStack {
+                        Image(systemName: "crown.fill")
+                            .foregroundColor(.orange)
+                        Text("升级到 Pro")
+                            .fontWeight(.medium)
+                    }
+
+                    VStack(alignment: .leading, spacing: 4) {
+                        FeatureRow(text: "无限映射规则")
+                        FeatureRow(text: "自定义预设管理")
+                        FeatureRow(text: "终身免费更新")
+                    }
+                    .padding(.leading, 4)
+
+                    Button {
+                        if let product = storeService.products.first {
+                            Task { await storeService.purchase(product) }
+                        }
+                    } label: {
+                        Text("一次性购买 \(storeService.proPriceString)")
+                            .frame(maxWidth: .infinity)
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .tint(.orange)
+
+                    Button("恢复购买") {
+                        Task { await storeService.restorePurchases() }
+                    }
+                    .font(.caption)
+                    .frame(maxWidth: .infinity)
+                }
+            }
+        } header: {
+            Text("PedalLink Pro")
+        }
+    }
+
+    /// 偏好设置
+    private var preferencesSection: some View {
+        Section("偏好设置") {
+            Toggle("触感反馈", isOn: $hapticFeedback)
+            Toggle("显示 MIDI 数值", isOn: $showMIDIValues)
+        }
+    }
+
+    /// 关于信息
+    private var aboutSection: some View {
+        Section("关于") {
+            HStack {
+                Text("版本")
+                Spacer()
+                Text(AppConstants.appVersion)
+                    .foregroundColor(.secondary)
+            }
+            HStack {
+                Text("开发者")
+                Spacer()
+                Text("PedalLink Team")
+                    .foregroundColor(.secondary)
+            }
+            Link(destination: URL(string: "https://pedallinkpro.com/support")!) {
+                Label("帮助与支持", systemImage: "questionmark.circle")
+            }
+            Link(destination: URL(string: "https://pedallinkpro.com/privacy")!) {
+                Label("隐私政策", systemImage: "hand.raised")
+            }
+        }
+    }
+}
+
+/// Pro 功能列表行
+struct FeatureRow: View {
+    let text: String
+
+    var body: some View {
+        HStack(spacing: 6) {
+            Image(systemName: "checkmark.circle.fill")
+                .font(.caption)
+                .foregroundColor(.orange)
+            Text(text)
+                .font(.caption)
+                .foregroundColor(.secondary)
+        }
+    }
+}

--- a/apps/pedallink-pro/PedalLinkProTests/HostInteropServiceTests.swift
+++ b/apps/pedallink-pro/PedalLinkProTests/HostInteropServiceTests.swift
@@ -1,0 +1,158 @@
+import XCTest
+@testable import PedalLinkPro
+
+/// HostAction 和 HostInteropService 单元测试
+final class HostInteropServiceTests: XCTestCase {
+
+    // MARK: - HostAction 测试
+
+    /// 测试 HostAction 显示字符串——静音
+    func testMuteActionDisplayString() {
+        let action = HostAction(hostApp: .aum, actionType: .mute, targetChannel: 0)
+        XCTAssertEqual(action.displayString, "AUM - 通道 1 静音切换")
+    }
+
+    /// 测试 HostAction 显示字符串——独奏
+    func testSoloActionDisplayString() {
+        let action = HostAction(hostApp: .aum, actionType: .solo, targetChannel: 2)
+        XCTAssertEqual(action.displayString, "AUM - 通道 3 独奏切换")
+    }
+
+    /// 测试 HostAction 显示字符串——选择通道
+    func testSelectChannelDisplayString() {
+        let action = HostAction(hostApp: .audiobus, actionType: .selectChannel, targetChannel: 4)
+        XCTAssertEqual(action.displayString, "Audiobus - 选择通道 5")
+    }
+
+    /// 测试 HostAction 显示字符串——音量
+    func testVolumeActionDisplayString() {
+        let action = HostAction(hostApp: .generic, actionType: .volume, targetChannel: 0, parameterValue: 100)
+        XCTAssertEqual(action.displayString, "通用 MIDI - 通道 1 音量 100")
+    }
+
+    // MARK: - HostApp 测试
+
+    /// 测试 AUM URL Scheme
+    func testAUMURLScheme() {
+        XCTAssertEqual(HostApp.aum.urlScheme, "aum")
+    }
+
+    /// 测试 Audiobus URL Scheme
+    func testAudiobusURLScheme() {
+        XCTAssertEqual(HostApp.audiobus.urlScheme, "audiobus")
+    }
+
+    /// 测试通用 MIDI 无 URL Scheme
+    func testGenericNoURLScheme() {
+        XCTAssertNil(HostApp.generic.urlScheme)
+    }
+
+    // MARK: - ChannelActionType 测试
+
+    /// 测试所有操作类型都有图标
+    func testAllActionTypesHaveIcons() {
+        for actionType in ChannelActionType.allCases {
+            XCTAssertFalse(actionType.iconName.isEmpty, "\(actionType.rawValue) 应有图标")
+        }
+    }
+
+    /// 测试操作类型枚举值
+    func testActionTypeCaseCount() {
+        XCTAssertEqual(ChannelActionType.allCases.count, 6)
+    }
+
+    // MARK: - MIDIMapping 匹配测试
+
+    /// 测试映射的 matches 方法
+    func testMappingMatches() {
+        let mapping = MIDIMapping(
+            name: "Test",
+            messageType: .controlChange,
+            midiChannel: 0,
+            controlNumber: 64,
+            triggerMode: .onPress,
+            thresholdValue: 64,
+            action: HostAction(hostApp: .aum, actionType: .mute, targetChannel: 0)
+        )
+
+        let matchMsg = MIDIMessage(
+            timestamp: Date(), type: .controlChange, channel: 0, number: 64, value: 127, sourceName: "Test"
+        )
+        let wrongCC = MIDIMessage(
+            timestamp: Date(), type: .controlChange, channel: 0, number: 65, value: 127, sourceName: "Test"
+        )
+        let wrongChannel = MIDIMessage(
+            timestamp: Date(), type: .controlChange, channel: 1, number: 64, value: 127, sourceName: "Test"
+        )
+        let wrongType = MIDIMessage(
+            timestamp: Date(), type: .noteOn, channel: 0, number: 64, value: 127, sourceName: "Test"
+        )
+        let belowThreshold = MIDIMessage(
+            timestamp: Date(), type: .controlChange, channel: 0, number: 64, value: 10, sourceName: "Test"
+        )
+
+        XCTAssertTrue(mapping.matches(matchMsg))
+        XCTAssertFalse(mapping.matches(wrongCC))
+        XCTAssertFalse(mapping.matches(wrongChannel))
+        XCTAssertFalse(mapping.matches(wrongType))
+        XCTAssertFalse(mapping.matches(belowThreshold))
+    }
+
+    /// 测试 toggle 触发模式
+    func testToggleTriggerMode() {
+        let mapping = MIDIMapping(
+            name: "Toggle Test",
+            messageType: .controlChange,
+            midiChannel: 0,
+            controlNumber: 64,
+            triggerMode: .toggle,
+            thresholdValue: 64,
+            action: HostAction(hostApp: .aum, actionType: .mute, targetChannel: 0)
+        )
+
+        let pressed = MIDIMessage(
+            timestamp: Date(), type: .controlChange, channel: 0, number: 64, value: 127, sourceName: "Test"
+        )
+        let released = MIDIMessage(
+            timestamp: Date(), type: .controlChange, channel: 0, number: 64, value: 0, sourceName: "Test"
+        )
+
+        XCTAssertTrue(mapping.matches(pressed), "Toggle 模式应在按下时匹配")
+        XCTAssertFalse(mapping.matches(released), "Toggle 模式不应在释放时匹配")
+    }
+
+    /// 测试 HostAction 的 Equatable 一致性
+    func testHostActionEquatable() {
+        let action1 = HostAction(id: UUID(), hostApp: .aum, actionType: .mute, targetChannel: 0)
+        var action2 = action1
+        action2.targetChannel = 1
+
+        XCTAssertNotEqual(action1, action2)
+    }
+
+    /// 测试 MIDIMapping 的 Codable 一致性
+    func testMappingCodable() throws {
+        let mapping = MIDIMapping(
+            name: "Codable Test",
+            messageType: .controlChange,
+            midiChannel: 5,
+            controlNumber: 11,
+            triggerMode: .momentary,
+            thresholdValue: 0,
+            action: HostAction(hostApp: .aum, actionType: .volume, targetChannel: 2, parameterValue: 100)
+        )
+
+        let encoded = try JSONEncoder().encode(mapping)
+        let decoded = try JSONDecoder().decode(MIDIMapping.self, from: encoded)
+
+        XCTAssertEqual(decoded.name, mapping.name)
+        XCTAssertEqual(decoded.messageType, mapping.messageType)
+        XCTAssertEqual(decoded.midiChannel, mapping.midiChannel)
+        XCTAssertEqual(decoded.controlNumber, mapping.controlNumber)
+        XCTAssertEqual(decoded.triggerMode, mapping.triggerMode)
+        XCTAssertEqual(decoded.action.hostApp, mapping.action.hostApp)
+        XCTAssertEqual(decoded.action.actionType, mapping.action.actionType)
+        XCTAssertEqual(decoded.action.targetChannel, mapping.action.targetChannel)
+        XCTAssertEqual(decoded.action.parameterValue, mapping.action.parameterValue)
+    }
+}

--- a/apps/pedallink-pro/PedalLinkProTests/MIDIMessageTests.swift
+++ b/apps/pedallink-pro/PedalLinkProTests/MIDIMessageTests.swift
@@ -1,0 +1,117 @@
+import XCTest
+@testable import PedalLinkPro
+
+/// MIDIMessage 模型单元测试
+final class MIDIMessageTests: XCTestCase {
+
+    // MARK: - 消息创建测试
+
+    /// 测试 CC 消息的正确创建
+    func testControlChangeMessageCreation() {
+        let message = MIDIMessage(
+            timestamp: Date(),
+            type: .controlChange,
+            channel: 0,
+            number: 64,
+            value: 127,
+            sourceName: "Test Device"
+        )
+
+        XCTAssertEqual(message.type, .controlChange)
+        XCTAssertEqual(message.channel, 0)
+        XCTAssertEqual(message.number, 64)
+        XCTAssertEqual(message.value, 127)
+        XCTAssertEqual(message.sourceName, "Test Device")
+    }
+
+    /// 测试 Note On 消息的正确创建
+    func testNoteOnMessageCreation() {
+        let message = MIDIMessage(
+            timestamp: Date(),
+            type: .noteOn,
+            channel: 5,
+            number: 60,
+            value: 100,
+            sourceName: "Pedal"
+        )
+
+        XCTAssertEqual(message.type, .noteOn)
+        XCTAssertEqual(message.channel, 5)
+        XCTAssertEqual(message.number, 60)
+        XCTAssertEqual(message.value, 100)
+    }
+
+    // MARK: - 显示字符串测试
+
+    /// 测试 CC 消息的显示格式
+    func testControlChangeDisplayString() {
+        let message = MIDIMessage(
+            timestamp: Date(),
+            type: .controlChange,
+            channel: 0,
+            number: 64,
+            value: 127,
+            sourceName: "Test"
+        )
+
+        XCTAssertEqual(message.displayString, "CC 64 = 127 [Ch 1]")
+    }
+
+    /// 测试 Note On 消息的显示格式
+    func testNoteOnDisplayString() {
+        let message = MIDIMessage(
+            timestamp: Date(),
+            type: .noteOn,
+            channel: 9,
+            number: 36,
+            value: 80,
+            sourceName: "Test"
+        )
+
+        XCTAssertEqual(message.displayString, "Note On 36 vel=80 [Ch 10]")
+    }
+
+    /// 测试 Program Change 消息的显示格式
+    func testProgramChangeDisplayString() {
+        let message = MIDIMessage(
+            timestamp: Date(),
+            type: .programChange,
+            channel: 2,
+            number: 5,
+            value: 0,
+            sourceName: "Test"
+        )
+
+        XCTAssertEqual(message.displayString, "PC 5 [Ch 3]")
+    }
+
+    // MARK: - 匹配键测试
+
+    /// 测试匹配键的唯一性
+    func testMatchKeyUniqueness() {
+        let msg1 = MIDIMessage(
+            timestamp: Date(), type: .controlChange, channel: 0, number: 64, value: 127, sourceName: "Test"
+        )
+        let msg2 = MIDIMessage(
+            timestamp: Date(), type: .controlChange, channel: 0, number: 64, value: 0, sourceName: "Test"
+        )
+        let msg3 = MIDIMessage(
+            timestamp: Date(), type: .controlChange, channel: 1, number: 64, value: 127, sourceName: "Test"
+        )
+
+        XCTAssertEqual(msg1.matchKey, msg2.matchKey, "相同类型/通道/编号应有相同 matchKey")
+        XCTAssertNotEqual(msg1.matchKey, msg3.matchKey, "不同通道应有不同 matchKey")
+    }
+
+    /// 测试不同消息类型的匹配键不同
+    func testMatchKeyDifferentTypes() {
+        let ccMsg = MIDIMessage(
+            timestamp: Date(), type: .controlChange, channel: 0, number: 64, value: 127, sourceName: "Test"
+        )
+        let noteMsg = MIDIMessage(
+            timestamp: Date(), type: .noteOn, channel: 0, number: 64, value: 127, sourceName: "Test"
+        )
+
+        XCTAssertNotEqual(ccMsg.matchKey, noteMsg.matchKey)
+    }
+}

--- a/apps/pedallink-pro/PedalLinkProTests/MappingEngineTests.swift
+++ b/apps/pedallink-pro/PedalLinkProTests/MappingEngineTests.swift
@@ -1,0 +1,229 @@
+import XCTest
+@testable import PedalLinkPro
+
+/// MappingEngine 核心逻辑单元测试
+final class MappingEngineTests: XCTestCase {
+    var engine: MappingEngine!
+
+    override func setUp() {
+        super.setUp()
+        engine = MappingEngine()
+    }
+
+    override func tearDown() {
+        engine = nil
+        super.tearDown()
+    }
+
+    // MARK: - CRUD 操作测试
+
+    /// 测试添加映射
+    func testAddMapping() {
+        let mapping = createTestMapping(name: "Test Mapping", cc: 64)
+        engine.addMapping(mapping)
+
+        XCTAssertEqual(engine.mappings.count, 1)
+        XCTAssertEqual(engine.mappings.first?.name, "Test Mapping")
+    }
+
+    /// 测试更新映射
+    func testUpdateMapping() {
+        var mapping = createTestMapping(name: "Original", cc: 64)
+        engine.addMapping(mapping)
+
+        mapping.name = "Updated"
+        engine.updateMapping(mapping)
+
+        XCTAssertEqual(engine.mappings.count, 1)
+        XCTAssertEqual(engine.mappings.first?.name, "Updated")
+    }
+
+    /// 测试删除映射
+    func testDeleteMapping() {
+        let mapping1 = createTestMapping(name: "Mapping 1", cc: 64)
+        let mapping2 = createTestMapping(name: "Mapping 2", cc: 65)
+        engine.addMapping(mapping1)
+        engine.addMapping(mapping2)
+
+        engine.deleteMapping(mapping1)
+
+        XCTAssertEqual(engine.mappings.count, 1)
+        XCTAssertEqual(engine.mappings.first?.name, "Mapping 2")
+    }
+
+    /// 测试批量删除
+    func testDeleteMappingsAtOffsets() {
+        for i in 0..<5 {
+            engine.addMapping(createTestMapping(name: "Mapping \(i)", cc: UInt8(60 + i)))
+        }
+
+        engine.deleteMappings(at: IndexSet([0, 2, 4]))
+
+        XCTAssertEqual(engine.mappings.count, 2)
+        XCTAssertEqual(engine.mappings[0].name, "Mapping 1")
+        XCTAssertEqual(engine.mappings[1].name, "Mapping 3")
+    }
+
+    // MARK: - 映射匹配测试
+
+    /// 测试 CC 消息匹配
+    func testCCMessageMatching() {
+        let mapping = createTestMapping(name: "CC64 Mute", cc: 64)
+        engine.addMapping(mapping)
+
+        let matchingMsg = MIDIMessage(
+            timestamp: Date(), type: .controlChange, channel: 0, number: 64, value: 127, sourceName: "Test"
+        )
+        let nonMatchingMsg = MIDIMessage(
+            timestamp: Date(), type: .controlChange, channel: 0, number: 65, value: 127, sourceName: "Test"
+        )
+
+        let matches = engine.findMatchingMappings(for: matchingMsg)
+        let nonMatches = engine.findMatchingMappings(for: nonMatchingMsg)
+
+        XCTAssertEqual(matches.count, 1)
+        XCTAssertEqual(nonMatches.count, 0)
+    }
+
+    /// 测试禁用的映射不匹配
+    func testDisabledMappingNotMatched() {
+        var mapping = createTestMapping(name: "Disabled", cc: 64)
+        mapping.isEnabled = false
+        engine.addMapping(mapping)
+
+        let message = MIDIMessage(
+            timestamp: Date(), type: .controlChange, channel: 0, number: 64, value: 127, sourceName: "Test"
+        )
+
+        let matches = engine.findMatchingMappings(for: message)
+        XCTAssertEqual(matches.count, 0)
+    }
+
+    /// 测试触发阈值——onPress 模式
+    func testOnPressTriggerThreshold() {
+        var mapping = createTestMapping(name: "OnPress", cc: 64)
+        mapping.triggerMode = .onPress
+        mapping.thresholdValue = 64
+        engine.addMapping(mapping)
+
+        let belowThreshold = MIDIMessage(
+            timestamp: Date(), type: .controlChange, channel: 0, number: 64, value: 63, sourceName: "Test"
+        )
+        let atThreshold = MIDIMessage(
+            timestamp: Date(), type: .controlChange, channel: 0, number: 64, value: 64, sourceName: "Test"
+        )
+        let aboveThreshold = MIDIMessage(
+            timestamp: Date(), type: .controlChange, channel: 0, number: 64, value: 127, sourceName: "Test"
+        )
+
+        XCTAssertEqual(engine.findMatchingMappings(for: belowThreshold).count, 0)
+        XCTAssertEqual(engine.findMatchingMappings(for: atThreshold).count, 1)
+        XCTAssertEqual(engine.findMatchingMappings(for: aboveThreshold).count, 1)
+    }
+
+    /// 测试 onRelease 触发模式
+    func testOnReleaseTriggerMode() {
+        var mapping = createTestMapping(name: "OnRelease", cc: 64)
+        mapping.triggerMode = .onRelease
+        mapping.thresholdValue = 64
+        engine.addMapping(mapping)
+
+        let released = MIDIMessage(
+            timestamp: Date(), type: .controlChange, channel: 0, number: 64, value: 0, sourceName: "Test"
+        )
+        let pressed = MIDIMessage(
+            timestamp: Date(), type: .controlChange, channel: 0, number: 64, value: 127, sourceName: "Test"
+        )
+
+        XCTAssertEqual(engine.findMatchingMappings(for: released).count, 1)
+        XCTAssertEqual(engine.findMatchingMappings(for: pressed).count, 0)
+    }
+
+    /// 测试 momentary 模式始终匹配
+    func testMomentaryTriggerAlwaysMatches() {
+        var mapping = createTestMapping(name: "Momentary", cc: 11)
+        mapping.triggerMode = .momentary
+        engine.addMapping(mapping)
+
+        for value: UInt8 in [0, 32, 64, 96, 127] {
+            let msg = MIDIMessage(
+                timestamp: Date(), type: .controlChange, channel: 0, number: 11, value: value, sourceName: "Test"
+            )
+            XCTAssertEqual(engine.findMatchingMappings(for: msg).count, 1, "值 \(value) 应匹配 momentary 映射")
+        }
+    }
+
+    /// 测试多个映射可以绑定同一 CC
+    func testMultipleMappingsForSameCC() {
+        let mapping1 = createTestMapping(name: "Mute Ch1", cc: 64, actionType: .mute, channel: 0)
+        let mapping2 = createTestMapping(name: "Solo Ch2", cc: 64, actionType: .solo, channel: 1)
+        engine.addMapping(mapping1)
+        engine.addMapping(mapping2)
+
+        let msg = MIDIMessage(
+            timestamp: Date(), type: .controlChange, channel: 0, number: 64, value: 127, sourceName: "Test"
+        )
+
+        let matches = engine.findMatchingMappings(for: msg)
+        XCTAssertEqual(matches.count, 2)
+    }
+
+    /// 测试不同 MIDI 通道的映射互不干扰
+    func testChannelIsolation() {
+        let mapping = createTestMapping(name: "Ch0 Only", cc: 64)
+        engine.addMapping(mapping)
+
+        let ch0Msg = MIDIMessage(
+            timestamp: Date(), type: .controlChange, channel: 0, number: 64, value: 127, sourceName: "Test"
+        )
+        let ch1Msg = MIDIMessage(
+            timestamp: Date(), type: .controlChange, channel: 1, number: 64, value: 127, sourceName: "Test"
+        )
+
+        XCTAssertEqual(engine.findMatchingMappings(for: ch0Msg).count, 1)
+        XCTAssertEqual(engine.findMatchingMappings(for: ch1Msg).count, 0)
+    }
+
+    // MARK: - 预设测试
+
+    /// 测试默认预设创建
+    func testDefaultPresetCreation() {
+        let preset = MappingEngine.createDefaultPreset(for: .aum)
+
+        XCTAssertEqual(preset.count, 4, "AUM 默认预设应包含 4 个映射")
+        XCTAssertTrue(preset.allSatisfy { $0.action.hostApp == .aum })
+        XCTAssertTrue(preset.allSatisfy { $0.isEnabled })
+    }
+
+    /// 测试加载预设
+    func testLoadPreset() {
+        engine.loadPreset(for: .aum)
+
+        XCTAssertEqual(engine.mappings.count, 4)
+        XCTAssertTrue(engine.mappings.allSatisfy { $0.action.hostApp == .aum })
+    }
+
+    // MARK: - 辅助方法
+
+    /// 创建测试用映射规则
+    private func createTestMapping(
+        name: String,
+        cc: UInt8,
+        actionType: ChannelActionType = .mute,
+        channel: Int = 0
+    ) -> MIDIMapping {
+        MIDIMapping(
+            name: name,
+            messageType: .controlChange,
+            midiChannel: 0,
+            controlNumber: cc,
+            triggerMode: .onPress,
+            thresholdValue: 64,
+            action: HostAction(
+                hostApp: .aum,
+                actionType: actionType,
+                targetChannel: channel
+            )
+        )
+    }
+}

--- a/apps/pedallink-pro/README.md
+++ b/apps/pedallink-pro/README.md
@@ -1,0 +1,74 @@
+# PedalLink Pro
+
+专为 iOS 音乐人设计的 MIDI 脚踏板映射工具。将物理脚踏板信号转化为 AUM 等宿主软件的通道控制指令，无需复杂设置，即连即用。
+
+## 核心功能
+
+- **MIDI CC 信号监听与识别** — 实时监控所有连接的 MIDI 设备，解析 CC、Note On/Off、Program Change 消息
+- **自定义脚踏动作映射** — 将任意 MIDI 信号映射为静音、独奏、通道选择、音量控制等操作
+- **AUM 及主流宿主互联** — 通过虚拟 MIDI 端口和 URL Scheme 与 AUM、Audiobus、GarageBand 等深度互联
+- **MIDI Learn 学习模式** — 踩下踏板自动识别信号，无需手动输入 CC 编号
+- **预设系统** — 内置常见脚踏板配置预设，一键加载
+
+## 技术架构
+
+```
+PedalLinkPro/
+├── App/                    # 应用入口
+├── Models/                 # 数据模型
+│   ├── MIDIMessage.swift   # MIDI 消息模型
+│   ├── MIDIMapping.swift   # 映射规则模型
+│   └── HostAction.swift    # 宿主操作模型
+├── Services/               # 服务层
+│   ├── MIDIService.swift   # CoreMIDI 服务（输入监听）
+│   ├── MappingEngine.swift # 映射引擎（核心逻辑）
+│   ├── HostInteropService.swift # 宿主互联服务（MIDI 输出 + URL Scheme）
+│   └── StoreKitService.swift    # StoreKit 2 购买服务
+├── ViewModels/             # 视图模型
+├── Views/                  # SwiftUI 视图
+│   ├── MIDIMonitorView     # MIDI 实时监视器
+│   ├── MappingListView     # 映射规则列表
+│   ├── MappingDetailView   # 映射编辑（含 MIDI Learn）
+│   ├── SettingsView        # 设置与购买
+│   └── Components/         # 可复用 UI 组件
+├── Utilities/              # 工具类
+└── Resources/              # 资源文件
+```
+
+## 技术要点
+
+| 模块 | 技术 |
+|------|------|
+| MIDI 输入 | CoreMIDI + MIDI 1.0 UMP 协议 |
+| MIDI 输出 | 虚拟 MIDI Source（MIDISourceCreateWithProtocol） |
+| AUM 控制 | URL Scheme (`aum://control`) + MIDI CC |
+| 映射索引 | 字典哈希 O(1) 查找 |
+| 持久化 | UserDefaults + Codable |
+| 付费 | StoreKit 2（一次性买断 $9.99） |
+| UI | SwiftUI + 深色模式 |
+| 最低版本 | iOS 17.0 |
+
+## 开发环境
+
+- Xcode 15.4+
+- iOS 17.0+ SDK
+- Swift 5.9+
+
+## 构建与运行
+
+1. 用 Xcode 打开 `PedalLinkPro.xcodeproj`
+2. 选择目标设备（推荐真机测试 MIDI 功能）
+3. 配置 Signing & Capabilities 中的开发者团队
+4. Build & Run
+
+## 变现模式
+
+一次性付费 $9.99，解锁全部功能，终身免费更新。免费版限制最多 3 个映射规则。
+
+## 测试
+
+项目包含完整的单元测试覆盖核心逻辑：
+
+- `MIDIMessageTests` — MIDI 消息模型测试
+- `MappingEngineTests` — 映射引擎匹配与 CRUD 测试
+- `HostInteropServiceTests` — 宿主操作与编解码测试


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## PedalLink Pro

专为 iOS 音乐人设计的 MIDI 脚踏板映射工具 MVP。将物理脚踏板信号转化为 AUM 等宿主软件的通道控制指令，即连即用，解决现场表演解放双手的痛点。

### 已实现的 MVP 功能

- [x] **MIDI CC 信号监听与识别** — CoreMIDI 服务实时监控 CC/Note/PC 消息
- [x] **自定义脚踏动作映射** — 4 种触发模式（按下/释放/切换/瞬时），6 种操作类型（静音/独奏/通道切换/音量/声相/发送）
- [x] **AUM 及主流 iOS 音频宿主互联** — 虚拟 MIDI 输出 + URL Scheme 双通道控制，支持 AUM/Audiobus/GarageBand/Cubasis

### 项目架构

| 层级 | 内容 |
|------|------|
| **Models** | `MIDIMessage`、`MIDIMapping`、`HostAction` — 数据模型，支持 Codable 序列化 |
| **Services** | `MIDIService`（CoreMIDI 输入）、`MappingEngine`（O(1) 索引匹配）、`HostInteropService`（虚拟 MIDI + URL Scheme）、`StoreKitService`（StoreKit 2 买断） |
| **Views** | MIDI 实时监视器、映射规则列表/编辑（含 MIDI Learn）、设置与设备管理 |
| **Tests** | 3 个测试文件共 20+ 测试用例覆盖消息模型、映射匹配、操作编解码 |

### 技术选型

- **SwiftUI** + iOS 17.0+
- **CoreMIDI** UMP 1.0 协议
- **StoreKit 2** 一次性买断 $9.99（免费版限 3 个映射）
- 深色模式 UI，触感反馈

### 文件清单 (29 files)

```
apps/pedallink-pro/
├── PedalLinkPro.xcodeproj/     # Xcode 项目配置
├── PedalLinkPro/
│   ├── App/                     # 应用入口
│   ├── Models/                  # MIDIMessage, MIDIMapping, HostAction
│   ├── Services/                # MIDIService, MappingEngine, HostInteropService, StoreKitService
│   ├── ViewModels/              # MIDIMonitorViewModel, MappingListViewModel
│   ├── Views/                   # ContentView, MIDIMonitorView, MappingListView, MappingDetailView, SettingsView
│   │   └── Components/          # MIDIActivityIndicator, PedalButton, ActionPickerView
│   ├── Utilities/               # Constants
│   └── Resources/               # Assets.xcassets, Info.plist
├── PedalLinkProTests/           # 单元测试
└── README.md
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-75f69b00-b5b6-4c4a-ae3c-9a1554ff10fd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-75f69b00-b5b6-4c4a-ae3c-9a1554ff10fd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

